### PR TITLE
feat: Ignore comment-only diff

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,10 +64,20 @@ runs:
 
     - name: check .gitignore
       id: check
-      run: git diff --name-only .gitignore | grep .gitignore || echo '' > /dev/stdout
+      run: |
+        git diff --name-only .gitignore | grep .gitignore || echo '' > /dev/stdout
+        # check if .gitignore is changed and not only comments
+        changed=$(git diff .gitignore | grep '^[+-][^+-]' | grep -v -e '^\+\s*#' -e '^\-\s*#' -e '^$') || echo '' > /dev/stdout
+        if [ -n "${changed}" ]; then
+            # echo "::save-state name=changed::true"
+            echo "changed=true" >> $GITHUB_STATE
+        else
+            echo "changed=false" >> $GITHUB_STATE
+        fi
       shell: bash
 
     - uses: peter-evans/create-pull-request@v6
+      if: steps.check.outputs.changed == 'true'
       id: create_pull_request
       with:
         branch: ${{ inputs.branch_name }}


### PR DESCRIPTION
gibo dumps may add a comment to the .gitignore file.
But it is usually meaningless to commit.
So, ignore the commit if the diff is only a comment.
