### PR TITLE
Automate action release preparation

### DIFF
--- a/.github/workflows/prepare-draft-release.yml
+++ b/.github/workflows/prepare-draft-release.yml
@@ -1,0 +1,45 @@
+name: prepare draft release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - action.yml
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Action release version tag (for example, v0.2.3)
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  draft-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve release version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          version="${INPUT_VERSION}"
+          if [ -z "${version}" ]; then
+            version="$(grep -Eo 'version=v[0-9][0-9.]*' action.yml | head -n1 | cut -d= -f2)"
+          fi
+          if [ -z "${version}" ]; then
+            echo "could not resolve release version" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create or update draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          name: ${{ steps.version.outputs.version }}
+          draft: true
+          generate_release_notes: true

--- a/.github/workflows/prepare-release-update.yml
+++ b/.github/workflows/prepare-release-update.yml
@@ -1,0 +1,49 @@
+name: prepare action release update
+
+on:
+  repository_dispatch:
+    types: [gitignore-in-release-published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Released gitignore.in version tag (for example, v0.2.0)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve released version
+        id: version
+        env:
+          DISPATCH_VERSION: ${{ github.event.client_payload.version }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          version="${DISPATCH_VERSION:-$INPUT_VERSION}"
+          if [ -z "${version}" ]; then
+            echo "version input is required" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Update bundled gitignore.in version
+        run: ./scripts/update-version.sh "${{ steps.version.outputs.version }}"
+
+      - name: Create update pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: chore/update-bundled-gitignore-in
+          delete-branch: true
+          commit-message: Update bundled gitignore.in
+          title: Update bundled gitignore.in to ${{ steps.version.outputs.version }}
+          body: |
+            Prepare the GitHub Action for the latest gitignore.in release.
+
+            - update the bundled `gitignore.in` download version to `${{ steps.version.outputs.version }}`

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ steps:
 - uses: gitignore-in/gh-action@main
 ```
 
+## Maintenance
+
+To update the bundled `gitignore.in` release manually:
+
+```bash
+./scripts/update-version.sh v0.2.0
+```
+
 ## License
 
 MIT

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:-${GITIGNORE_IN_VERSION:-}}"
+if [ -z "${version}" ]; then
+  echo "usage: $0 <version>" >&2
+  exit 1
+fi
+
+sed -i.bak \
+  -e "s/version=v[0-9][0-9.]*$/version=${version}/" \
+  -e "s/gitignore-in-x86_64-unknown-linux-gnu-v[0-9][0-9.]*\\.tar\\.gz/gitignore-in-x86_64-unknown-linux-gnu-${version}.tar.gz/" \
+  action.yml
+
+rm -f action.yml.bak


### PR DESCRIPTION
## Summary
- prepare version bump PRs automatically from upstream `gitignore-in` release dispatches
- add a small helper script for updating the bundled download version
- create a draft release automatically after `action.yml` changes land on `main`

## Testing
- ./scripts/update-version.sh v0.2.0
- bash -n scripts/update-version.sh

Closes #13
