### PR TITLE
Add dry-run action rehearsal

### DIFF
--- a/.github/workflows/prepare-release-update.yml
+++ b/.github/workflows/prepare-release-update.yml
@@ -9,32 +9,79 @@ on:
         description: Released gitignore.in version tag (for example, v0.2.0)
         required: true
         type: string
+      mode:
+        description: Whether to open a PR or only rehearse the update
+        required: false
+        default: prepare-pr
+        type: choice
+        options:
+          - prepare-pr
+          - dry-run
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
-  prepare-update:
+  resolve:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      mode: ${{ steps.resolve.outputs.mode }}
     steps:
       - uses: actions/checkout@v6
 
       - name: Resolve released version
-        id: version
+        id: resolve
         env:
           DISPATCH_VERSION: ${{ github.event.client_payload.version }}
           INPUT_VERSION: ${{ inputs.version }}
+          DISPATCH_MODE: ${{ github.event.client_payload.mode }}
+          INPUT_MODE: ${{ inputs.mode }}
         run: |
           version="${DISPATCH_VERSION:-$INPUT_VERSION}"
           if [ -z "${version}" ]; then
             echo "version input is required" >&2
             exit 1
           fi
+          mode="${DISPATCH_MODE:-${INPUT_MODE:-prepare-pr}}"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "mode=${mode}" >> "${GITHUB_OUTPUT}"
+
+  validate:
+    runs-on: ubuntu-latest
+    needs: resolve
+    steps:
+      - uses: actions/checkout@v6
 
       - name: Update bundled gitignore.in version
-        run: ./scripts/update-version.sh "${{ steps.version.outputs.version }}"
+        run: ./scripts/update-version.sh "${{ needs.resolve.outputs.version }}"
+
+      - name: Download bundled release artifact
+        run: |
+          version="$(grep -Eo 'version=v[0-9][0-9.]*' action.yml | head -n1 | cut -d= -f2)"
+          target="$(grep -Eo 'gitignore-in-x86_64-unknown-linux-gnu-v[0-9][0-9.]*\.tar\.gz' action.yml | head -n1)"
+          url="https://github.com/gitignore-in/gitignore-in/releases/download/${version}/${target}"
+          wget "${url}"
+          tar -xzf "${target}"
+
+      - name: Smoke test bundled binary
+        run: |
+          mkdir -p .tmp/rehearsal
+          cd .tmp/rehearsal
+          printf 'echo \".env\"\n' > .gitignore.in
+          ../../gitignore.in
+          grep '\.env' .gitignore
+
+  prepare-update:
+    runs-on: ubuntu-latest
+    needs: [resolve, validate]
+    if: ${{ needs.resolve.outputs.mode != 'dry-run' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update bundled gitignore.in version
+        run: ./scripts/update-version.sh "${{ needs.resolve.outputs.version }}"
 
       - name: Create update pull request
         uses: peter-evans/create-pull-request@v8
@@ -42,8 +89,8 @@ jobs:
           branch: chore/update-bundled-gitignore-in
           delete-branch: true
           commit-message: Update bundled gitignore.in
-          title: Update bundled gitignore.in to ${{ steps.version.outputs.version }}
+          title: Update bundled gitignore.in to ${{ needs.resolve.outputs.version }}
           body: |
             Prepare the GitHub Action for the latest gitignore.in release.
 
-            - update the bundled `gitignore.in` download version to `${{ steps.version.outputs.version }}`
+            - update the bundled `gitignore.in` download version to `${{ needs.resolve.outputs.version }}`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ To update the bundled `gitignore.in` release manually:
 ./scripts/update-version.sh v0.2.0
 ```
 
+To rehearse the release-preparation workflow without opening a PR, run
+`prepare action release update` with `mode=dry-run`.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- add a `mode` input to the action release-preparation workflow
- validate the bundled release artifact before opening a PR
- allow `mode=dry-run` rehearsals without creating a PR

## Testing
- ./scripts/update-version.sh v0.2.0
- bash -n scripts/update-version.sh
- local binary smoke test is not runnable on macOS because the bundled artifact is Linux-only; the workflow validates it on `ubuntu-latest`

Closes #15
