### PR TITLE
Install gitignore-in for runner platform

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,13 +49,31 @@ runs:
         tmpdir=$(mktemp -d)
         cd "${tmpdir}"
         version=v0.2.0
-        # TODO: support other platform
-        target=gitignore-in-x86_64-unknown-linux-gnu-v0.2.0.tar.gz
+        case "${RUNNER_OS}-${RUNNER_ARCH}" in
+          Linux-X64)
+            target="gitignore-in-x86_64-unknown-linux-gnu-${version}.tar.gz"
+            ;;
+          Linux-ARM64)
+            target="gitignore-in-aarch64-unknown-linux-gnu-${version}.tar.gz"
+            ;;
+          macOS-X64)
+            target="gitignore-in-x86_64-apple-darwin-${version}.tar.gz"
+            ;;
+          macOS-ARM64)
+            target="gitignore-in-aarch64-apple-darwin-${version}.tar.gz"
+            ;;
+          *)
+            echo "Unsupported runner platform: ${RUNNER_OS}-${RUNNER_ARCH}" >&2
+            exit 1
+            ;;
+        esac
         url="https://github.com/gitignore-in/gitignore-in/releases/download/${version}/${target}"
         wget "${url}"
         tar -xzf "${target}"
-        cp gitignore.in /usr/local/bin
-        chmod +x /usr/local/bin/gitignore.in
+        mkdir -p "${RUNNER_TEMP}/gitignore-in/bin"
+        cp gitignore.in "${RUNNER_TEMP}/gitignore-in/bin/gitignore.in"
+        chmod +x "${RUNNER_TEMP}/gitignore-in/bin/gitignore.in"
+        echo "${RUNNER_TEMP}/gitignore-in/bin" >> "${GITHUB_PATH}"
         rm -rf "${tmpdir}"
       shell: bash
 

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -9,7 +9,6 @@ fi
 
 sed -i.bak \
   -e "s/version=v[0-9][0-9.]*$/version=${version}/" \
-  -e "s/gitignore-in-x86_64-unknown-linux-gnu-v[0-9][0-9.]*\\.tar\\.gz/gitignore-in-x86_64-unknown-linux-gnu-${version}.tar.gz/" \
   action.yml
 
 rm -f action.yml.bak


### PR DESCRIPTION
## Summary
- Select the gitignore-in release asset from RUNNER_OS and RUNNER_ARCH.
- Install the binary into RUNNER_TEMP and expose it through GITHUB_PATH instead of writing to /usr/local/bin.
- Keep the version updater focused on the shared version variable now that asset names are derived at runtime.

## Verification
- ruby -e 'require "yaml"; YAML.load_file("action.yml"); puts "yaml ok"'
- bash -n scripts/update-version.sh
- git diff --check
