### PR TITLE
Validate release update dispatch inputs

### DIFF
--- a/.github/workflows/prepare-release-update.yml
+++ b/.github/workflows/prepare-release-update.yml
@@ -44,7 +44,19 @@ jobs:
             echo "version input is required" >&2
             exit 1
           fi
+          if ! [[ "${version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "version must use vMAJOR.MINOR.PATCH format: ${version}" >&2
+            exit 1
+          fi
           mode="${DISPATCH_MODE:-${INPUT_MODE:-prepare-pr}}"
+          case "${mode}" in
+            prepare-pr|dry-run)
+              ;;
+            *)
+              echo "mode must be prepare-pr or dry-run: ${mode}" >&2
+              exit 1
+              ;;
+          esac
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
           echo "mode=${mode}" >> "${GITHUB_OUTPUT}"
 
@@ -53,6 +65,11 @@ jobs:
     needs: resolve
     steps:
       - uses: actions/checkout@v6
+
+      - name: Verify released version exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release view "${{ needs.resolve.outputs.version }}" --repo gitignore-in/gitignore-in >/dev/null
 
       - name: Update bundled gitignore.in version
         run: ./scripts/update-version.sh "${{ needs.resolve.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ To update the bundled `gitignore.in` release manually:
 
 To rehearse the release-preparation workflow without opening a PR, run
 `prepare action release update` with `mode=dry-run`.
+The workflow accepts `vMAJOR.MINOR.PATCH` release tags and verifies the
+corresponding `gitignore-in/gitignore-in` release before updating `action.yml`.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Validate release update versions before writing them to workflow outputs.
- Restrict the release update mode to `prepare-pr` or `dry-run`.
- Check that the requested `gitignore-in/gitignore-in` release exists before updating `action.yml`.

## Validation

- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/prepare-release-update.yml"); puts "yaml ok"'
- actionlint .github/workflows/prepare-release-update.yml
- bash -n scripts/update-version.sh
- gh release view v0.2.0 --repo gitignore-in/gitignore-in