### PR TITLE
Verify SHA-256 of bundled gitignore.in tarball before extracting

### DIFF
--- a/.github/workflows/prepare-release-update.yml
+++ b/.github/workflows/prepare-release-update.yml
@@ -76,10 +76,13 @@ jobs:
 
       - name: Download bundled release artifact
         run: |
+          set -euo pipefail
           version="$(grep -Eo 'version=v[0-9][0-9.]*' action.yml | head -n1 | cut -d= -f2)"
           target="$(grep -Eo 'gitignore-in-x86_64-unknown-linux-gnu-v[0-9][0-9.]*\.tar\.gz' action.yml | head -n1)"
           url="https://github.com/gitignore-in/gitignore-in/releases/download/${version}/${target}"
           wget "${url}"
+          grep -F "  ${target}" bundled-binary.sha256 > "${target}.sha256"
+          shasum -a 256 -c "${target}.sha256"
           tar -xzf "${target}"
 
       - name: Smoke test bundled binary

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,9 @@ runs:
 
     - uses: gitignore-in/install-gibo@9e7dba9e59f184b41f542669b0864687a6f69b45 # v0.1.0
     - run: |
+        set -euo pipefail
         tmpdir=$(mktemp -d)
+        trap 'rm -rf "${tmpdir}"' EXIT
         cd "${tmpdir}"
         version=v0.2.0
         case "${RUNNER_OS}-${RUNNER_ARCH}" in
@@ -69,12 +71,13 @@ runs:
         esac
         url="https://github.com/gitignore-in/gitignore-in/releases/download/${version}/${target}"
         wget "${url}"
+        grep -F "  ${target}" "${{ github.action_path }}/bundled-binary.sha256" > "${target}.sha256"
+        shasum -a 256 -c "${target}.sha256"
         tar -xzf "${target}"
         mkdir -p "${RUNNER_TEMP}/gitignore-in/bin"
         cp gitignore.in "${RUNNER_TEMP}/gitignore-in/bin/gitignore.in"
         chmod +x "${RUNNER_TEMP}/gitignore-in/bin/gitignore.in"
         echo "${RUNNER_TEMP}/gitignore-in/bin" >> "${GITHUB_PATH}"
-        rm -rf "${tmpdir}"
       shell: bash
 
     - name: run gitignore.in

--- a/bundled-binary.sha256
+++ b/bundled-binary.sha256
@@ -1,0 +1,4 @@
+58a6d8145ec4bba03319df66c3468971a8e51431d785c86bac00e41fae769a81  gitignore-in-x86_64-unknown-linux-gnu-v0.2.0.tar.gz
+b3cbaa41baa7fbd7f2cd49bd363f03ba29a40ed7b9d26ecc8a86e3bc26c8a6c5  gitignore-in-aarch64-unknown-linux-gnu-v0.2.0.tar.gz
+35fbabf95337bf3e8871ce4c610c3caa72fa7ce1d5f52042ce3c55e3dfa1206d  gitignore-in-x86_64-apple-darwin-v0.2.0.tar.gz
+4d934798f90a7d5c1da9c29c2127867698bb9a7df24da105eb1b936a18da9cc3  gitignore-in-aarch64-apple-darwin-v0.2.0.tar.gz

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -7,8 +7,38 @@ if [ -z "${version}" ]; then
 	exit 1
 fi
 
+if ! [[ "${version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+	echo "version must use vMAJOR.MINOR.PATCH format: ${version}" >&2
+	exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+
 sed -i.bak \
 	-e "s/version=v[0-9][0-9.]*$/version=${version}/" \
-	action.yml
+	"${repo_root}/action.yml"
 
-rm -f action.yml.bak
+rm -f "${repo_root}/action.yml.bak"
+
+# Regenerate bundled-binary.sha256 against the upstream release tarballs so
+# the action's wget step can verify each platform's bytes before extracting.
+archs=(
+	"x86_64-unknown-linux-gnu"
+	"aarch64-unknown-linux-gnu"
+	"x86_64-apple-darwin"
+	"aarch64-apple-darwin"
+)
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+release_url="https://github.com/gitignore-in/gitignore-in/releases/download/${version}"
+checksum_file="${repo_root}/bundled-binary.sha256"
+: >"${checksum_file}"
+
+for arch in "${archs[@]}"; do
+	target="gitignore-in-${arch}-${version}.tar.gz"
+	curl --fail --location --silent --show-error --output "${tmpdir}/${target}" "${release_url}/${target}"
+	(cd "${tmpdir}" && shasum -a 256 "${target}") >>"${checksum_file}"
+done


### PR DESCRIPTION
## Summary

- Pin the expected SHA-256 of each platform's release tarball in `bundled-binary.sha256` and verify with `shasum -a 256 -c` between `wget` and `tar -xzf`, so a tampered or wrong-bytes tarball stops the action before it lands on `${GITHUB_PATH}`.
- Match the existing pattern used by sister action `gitignore-in/install-gibo`, which already verifies its release artifact against `checksums.txt`.
- Teach `scripts/update-version.sh` to fetch the four supported platform tarballs from the upstream release and regenerate `bundled-binary.sha256`, so the pinned digests stay in lockstep with the `version=` literal in `action.yml`.
- Extend the `prepare action release update` workflow's smoke test step to verify the downloaded Linux-x64 tarball against the regenerated checksums, so a corrupted or tampered release fails the pre-merge rehearsal.

## Test plan

- [x] `bash -n scripts/update-version.sh`
- [x] `shfmt -d scripts/*.sh`
- [x] `typos`
- [x] `./scripts/update-version.sh v0.2.0` regenerates `bundled-binary.sha256` byte-identical to the committed version (sanity round-trip)
- [x] Locally simulated the action's verify step (`grep -F` + `shasum -a 256 -c`) against `gitignore-in-x86_64-unknown-linux-gnu-v0.2.0.tar.gz` from the `v0.2.0` release: `gitignore-in-x86_64-unknown-linux-gnu-v0.2.0.tar.gz: OK`
- [ ] CI: `Example` workflow (`example` job) runs the composite action end-to-end on `ubuntu-latest`