### PR TITLE
Resolve draft release version from the action's own release tag

### DIFF
--- a/.github/workflows/prepare-draft-release.yml
+++ b/.github/workflows/prepare-draft-release.yml
@@ -24,14 +24,27 @@ jobs:
       - name: Resolve release version
         id: version
         env:
+          GH_TOKEN: ${{ github.token }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           version="${INPUT_VERSION}"
           if [ -z "${version}" ]; then
-            version="$(grep -Eo 'version=v[0-9][0-9.]*' action.yml | head -n1 | cut -d= -f2)"
+            latest="$(gh release view --repo "${GITHUB_REPOSITORY}" --json tagName --jq '.tagName')"
+            if [ -z "${latest}" ]; then
+              echo "no latest release found; provide a version via workflow_dispatch input" >&2
+              exit 1
+            fi
+            if ! [[ "${latest}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+              echo "latest release tag does not match vMAJOR.MINOR.PATCH: ${latest}" >&2
+              exit 1
+            fi
+            major="${BASH_REMATCH[1]}"
+            minor="${BASH_REMATCH[2]}"
+            patch="${BASH_REMATCH[3]}"
+            version="v${major}.${minor}.$((patch + 1))"
           fi
-          if [ -z "${version}" ]; then
-            echo "could not resolve release version" >&2
+          if ! [[ "${version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "version must use vMAJOR.MINOR.PATCH format: ${version}" >&2
             exit 1
           fi
           echo "version=${version}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary

`prepare-draft-release.yml` was reading `version=v0.2.0` from `action.yml`
to choose the draft release tag. That string is the version of the
*bundled* `gitignore.in` binary, not the action's own release namespace
(currently `v0.2.3`), so every run targeted the published `v0.2.0`
release and `softprops/action-gh-release@v3` silently rewrote its body.
The v0.2.0 release notes already contain four duplicated "What's Changed"
blocks as a result.

This change resolves the draft tag from the action's own latest release
via `gh release view` and bumps the patch component. The
`workflow_dispatch` input keeps its role as a manual override for
minor/major bumps. Both paths are now validated against
`vMAJOR.MINOR.PATCH`.

## Behavior

- Push to `main` touching `action.yml`: workflow targets `v<latest>.<patch+1>` as a draft.
- `workflow_dispatch` with `version: v0.3.0`: workflow targets `v0.3.0` as a draft.
- Latest release missing or non-semver: fail fast with a descriptive error.

## Test plan

- [ ] CI: actionlint passes (verified locally).
- [ ] After merge: trigger `workflow_dispatch` with `version: v0.2.4` (or just run on the next `action.yml` change) and confirm a *new* draft release is created instead of the published `v0.2.0` being modified.
- [ ] Confirm `softprops/action-gh-release` log shows `tag_name: v0.2.4` (or the manually supplied tag), not `v0.2.0`.