### PR TITLE
Add actionlint and shellcheck to shell quality gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,20 @@ jobs:
           go-version: stable
       - run: go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh
 
+  shell-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: stable
+      - name: actionlint (workflow yml + composite action.yml inline shell)
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color
+      - name: shellcheck (scripts/*.sh)
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
+        with:
+          scandir: ./scripts
+
   diff-detection:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Add a `shell-lint` job to `.github/workflows/main.yml` that runs `actionlint` (transitively shellcheck on every inline `run:` block in workflow YAML and composite `action.yml`) and `shellcheck` directly on `scripts/*.sh`.
- The existing `shell-format` job only covers `scripts/*.sh` with `shfmt -d`, which leaves the install-bundled-binary heredoc in `action.yml:48-81` — the most frequently executed shell in this repo for every consumer's CI — outside any lint coverage. This change closes that gap without changing the runtime behavior of the action.
- Both tools are version-pinned: `actionlint` via `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`, and the `shellcheck` runner via `ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38` (2.0.0), matching the repo's existing pinning discipline (renovate-compatible).

## Test plan

- [x] `actionlint -color` passes locally on `main`+patch (no existing violations under v1.7.12).
- [x] `shellcheck scripts/*.sh` passes locally on `main`+patch.
- [x] `shfmt -d scripts/*.sh` still passes (existing `shell-format` job untouched).
- [ ] CI on this PR runs the new `shell-lint` job and both checks pass.