### PR TITLE
Stage update-version.sh writes so partial failures leave the repo unchanged

### DIFF
--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -15,12 +15,6 @@ fi
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/.." && pwd)"
 
-sed -i.bak \
-	-e "s/version=v[0-9][0-9.]*$/version=${version}/" \
-	"${repo_root}/action.yml"
-
-rm -f "${repo_root}/action.yml.bak"
-
 # Regenerate bundled-binary.sha256 against the upstream release tarballs so
 # the action's wget step can verify each platform's bytes before extracting.
 archs=(
@@ -35,10 +29,49 @@ trap 'rm -rf "${tmpdir}"' EXIT
 
 release_url="https://github.com/gitignore-in/gitignore-in/releases/download/${version}"
 checksum_file="${repo_root}/bundled-binary.sha256"
-: >"${checksum_file}"
+action_file="${repo_root}/action.yml"
+# Build the new checksum file in tmpdir first; only mutate the in-repo files
+# once every platform has been fetched and hashed. A partial failure must not
+# leave action.yml pinned to a new version while bundled-binary.sha256 still
+# carries the old one (or vice versa), because that combination silently fails
+# at consumer workflow run time instead of at update-version.sh time.
+staging_file="${tmpdir}/bundled-binary.sha256"
+: >"${staging_file}"
 
 for arch in "${archs[@]}"; do
 	target="gitignore-in-${arch}-${version}.tar.gz"
 	curl --fail --location --silent --show-error --output "${tmpdir}/${target}" "${release_url}/${target}"
-	(cd "${tmpdir}" && shasum -a 256 "${target}") >>"${checksum_file}"
+	(cd "${tmpdir}" && shasum -a 256 "${target}") >>"${staging_file}"
 done
+
+# Cross-check that every requested arch has exactly one line carrying the
+# requested version suffix before we touch any in-repo file. This catches
+# truncation, duplicate appends, or accidental version drift in one place.
+expected_lines="${#archs[@]}"
+actual_lines="$(wc -l <"${staging_file}" | tr -d ' ')"
+if [ "${actual_lines}" != "${expected_lines}" ]; then
+	echo "expected ${expected_lines} sha256 lines, got ${actual_lines}" >&2
+	exit 1
+fi
+for arch in "${archs[@]}"; do
+	target="gitignore-in-${arch}-${version}.tar.gz"
+	matches="$(grep -cF "  ${target}" "${staging_file}" || true)"
+	if [ "${matches}" != "1" ]; then
+		echo "sha256 entry for ${target} appeared ${matches} times (expected 1)" >&2
+		exit 1
+	fi
+done
+
+# Stage the action.yml rewrite next to the new checksum file. We only swap
+# both into the repo after they have both been produced successfully.
+staging_action="${tmpdir}/action.yml"
+sed \
+	-e "s/version=v[0-9][0-9.]*$/version=${version}/" \
+	"${action_file}" >"${staging_action}"
+if ! grep -qE "^[[:space:]]*version=${version}\$" "${staging_action}"; then
+	echo "action.yml version= line did not update to ${version}" >&2
+	exit 1
+fi
+
+mv "${staging_action}" "${action_file}"
+mv "${staging_file}" "${checksum_file}"


### PR DESCRIPTION
## Why

`scripts/update-version.sh` is the one place that has to keep `action.yml`'s
`version=` pin and `bundled-binary.sha256` aligned. Today the script edits
`action.yml` first, then truncates the checksum file with `:
>"${checksum_file}"`, and finally appends each platform's `sha256` inside the
`curl` loop. If `curl` fails partway through (rate-limited mirror, missing
asset for one platform, transient network), the repo is left in a partial
state:

- `action.yml` is pinned to the new tag,
- `bundled-binary.sha256` is empty or only partially populated.

The combination passes PR review and CI silently. It first surfaces at
**consumer workflow run time**: the action's `wget` step succeeds, but the
follow-up `grep -F "  ${target}" bundled-binary.sha256` produces no row, and
`shasum -a 256 -c` then fails on empty input. The fail-close behaviour is
correct, but the detection point is far away from the operator who ran
`update-version.sh`.

## What

- Build the new `bundled-binary.sha256` inside a tmpdir.
- Validate the staged file has exactly one entry per supported arch and that
  each entry carries the requested version suffix.
- Stage the `action.yml` rewrite next to the new checksum file in the same
  tmpdir and verify the rewrite produced the expected `version=` line.
- Only `mv` both files into the repo after every step above has succeeded.

A `curl`, hash, or validation failure now aborts before either in-repo file
is touched; recovery is `git status` clean and re-running the script.

## How tested

- `shfmt -d scripts/*.sh` — no diff.
- `shellcheck scripts/update-version.sh` — clean.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color` — clean.
- `./scripts/update-version.sh v0.2.0` against the existing release:
  `action.yml` and `bundled-binary.sha256` are byte-identical before and
  after.
- `./scripts/update-version.sh v9.9.9` (deliberately non-existent tag): the
  script exits non-zero on the first 404, and `git diff` shows no change to
  `action.yml` or `bundled-binary.sha256`.