### PR TITLE
feat: expose commit_message, pr_title, pr_body, delete_branch as inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,30 @@ inputs:
       Default: main
     required: false
     default: main
+  commit_message:
+    description: |
+      Commit message for the .gitignore update.
+      Default: Update .gitignore by gitignore.in
+    required: false
+    default: Update .gitignore by gitignore.in
+  pr_title:
+    description: |
+      Pull request title.
+      Default: Update .gitignore
+    required: false
+    default: Update .gitignore
+  pr_body:
+    description: |
+      Pull request body.
+      Default: Update .gitignore by gitignore.in
+    required: false
+    default: Update .gitignore by gitignore.in
+  delete_branch:
+    description: |
+      Whether to delete the branch after the pull request is merged.
+      Default: true
+    required: false
+    default: "true"
 outputs:
   pull-request-number:
     description: Pull request number.
@@ -99,10 +123,9 @@ runs:
         branch: ${{ inputs.branch_name }}
         base: ${{ inputs.base_branch }}
         path: repository
-        commit-message: Update .gitignore by gitignore.in
-        delete-branch: true
-        title: Update .gitignore
-        body: |
-          Update .gitignore by gitignore.in
+        commit-message: ${{ inputs.commit_message }}
+        delete-branch: ${{ inputs.delete_branch }}
+        title: ${{ inputs.pr_title }}
+        body: ${{ inputs.pr_body }}
       env:
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Exposes four previously hard-coded `peter-evans/create-pull-request` fields as optional action inputs, keeping the existing values as defaults.

| New input | Default (unchanged) |
|-----------|---------------------|
| `commit_message` | `Update .gitignore by gitignore.in` |
| `pr_title` | `Update .gitignore` |
| `pr_body` | `Update .gitignore by gitignore.in` |
| `delete_branch` | `true` |

## Motivation

Users whose repos use custom commit conventions (conventional commits, Japanese commit messages, PR templates) had no way to align the generated PR with their house style. The change is fully backward-compatible — existing callers that specify no new inputs see identical behavior.

## Test plan

- [ ] Existing callers with no new inputs: behavior unchanged
- [ ] Caller with `commit_message: "chore: update .gitignore"` produces the expected commit message
- [ ] CI actionlint passes