### PR TITLE
Use POSIX whitespace matching in diff check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,12 @@ jobs:
           scandir: ./scripts
 
   diff-detection:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -46,7 +51,7 @@ jobs:
           git config user.email test@example.com
           git add .gitignore
           git commit -m init
-          printf '\n# comment-only change\n' >> .gitignore
+          printf '\n # comment-only change\n\t# tab-indented comment-only change\n' >> .gitignore
           export GITHUB_OUTPUT="${tmpdir}/output.txt"
           "${GITHUB_WORKSPACE}/scripts/has-meaningful-gitignore-diff.sh" .gitignore
           grep '^changed=false$' "${GITHUB_OUTPUT}"

--- a/scripts/has-meaningful-gitignore-diff.sh
+++ b/scripts/has-meaningful-gitignore-diff.sh
@@ -10,7 +10,7 @@ fi
 
 if git diff -- "${target}" |
 	grep '^[+-][^+-]' |
-	grep -vq -e '^[+-]\s*#' -e '^$'; then
+	grep -vq -e '^[+-][[:space:]]*#' -e '^$'; then
 	echo "changed=true" >>"${GITHUB_OUTPUT:-/dev/stdout}"
 else
 	echo "changed=false" >>"${GITHUB_OUTPUT:-/dev/stdout}"


### PR DESCRIPTION
## Summary
- Replace the diff helper's non-portable `\\s` grep pattern with the POSIX `[[:space:]]` character class.
- Run the diff-detection job on both Ubuntu and macOS so BSD grep behavior is covered.
- Extend the comment-only diff fixture to include space- and tab-indented comment lines.

## Verification
- `shfmt -d scripts/*.sh`
- `shellcheck scripts/*.sh`
- `actionlint -color`
- Comment-only `.gitignore` diff fixture emits `changed=false`
- Meaningful `.gitignore` diff fixture emits `changed=true`
- `git diff --check`
