### PR TITLE
Detect untracked .gitignore as changed in diff detection script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,18 @@ jobs:
           "${GITHUB_WORKSPACE}/scripts/has-meaningful-gitignore-diff.sh" .gitignore
           grep '^changed=true$' "${GITHUB_OUTPUT}"
 
+      - name: untracked file is detected as changed
+        run: |
+          tmpdir=$(mktemp -d)
+          cd "${tmpdir}"
+          git init
+          git config user.name test
+          git config user.email test@example.com
+          printf 'node_modules/\n' > .gitignore
+          export GITHUB_OUTPUT="${tmpdir}/output.txt"
+          "${GITHUB_WORKSPACE}/scripts/has-meaningful-gitignore-diff.sh" .gitignore
+          grep '^changed=true$' "${GITHUB_OUTPUT}"
+
   example:
     runs-on: ubuntu-latest
     name: test

--- a/scripts/has-meaningful-gitignore-diff.sh
+++ b/scripts/has-meaningful-gitignore-diff.sh
@@ -3,6 +3,12 @@ set -euo pipefail
 
 target="${1:-.gitignore}"
 
+# Untracked (newly generated) file is always a meaningful change.
+if git ls-files --others -- "${target}" | grep -q .; then
+	echo "changed=true" >>"${GITHUB_OUTPUT:-/dev/stdout}"
+	exit 0
+fi
+
 if ! git diff --name-only -- "${target}" | grep -q .; then
 	echo "changed=false" >>"${GITHUB_OUTPUT:-/dev/stdout}"
 	exit 0


### PR DESCRIPTION
## Summary

- Add `git ls-files --others` guard to `scripts/has-meaningful-gitignore-diff.sh` to detect newly generated (untracked) files
- Add test case for the untracked initial-bootstrap scenario to `diff-detection` job in CI

## Problem

`git diff --name-only` only reports changes to tracked files. When a `.gitignore` is newly generated by `gitignore-in` and was never committed before, it remains untracked. The existing guard always sees no diff output and emits `changed=false`, causing `peter-evans/create-pull-request` to be skipped — the action completes successfully but no PR is created.

## Fix

```sh
# Untracked (newly generated) file is always a meaningful change.
if git ls-files --others -- "${target}" | grep -q .; then
    echo "changed=true" >>"${GITHUB_OUTPUT:-/dev/stdout}"
    exit 0
fi
```

If the target file is untracked, immediately emit `changed=true`. The existing tracked-diff logic is unchanged.

## Test plan

- [ ] CI `diff-detection` job: existing "comment-only diff is ignored" case still passes
- [ ] CI `diff-detection` job: existing "meaningful diff is detected" case still passes
- [ ] CI `diff-detection` job: new "untracked file is detected as changed" case passes