### PR TITLE
Add trap cleanup to diff-detection test tmpdirs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,7 @@ jobs:
       - name: comment-only diff is ignored
         run: |
           tmpdir=$(mktemp -d)
+          trap 'rm -rf "${tmpdir}"' EXIT
           cp .gitignore "${tmpdir}/.gitignore"
           cd "${tmpdir}"
           git init
@@ -59,6 +60,7 @@ jobs:
       - name: meaningful diff is detected
         run: |
           tmpdir=$(mktemp -d)
+          trap 'rm -rf "${tmpdir}"' EXIT
           cp .gitignore "${tmpdir}/.gitignore"
           cd "${tmpdir}"
           git init
@@ -74,6 +76,7 @@ jobs:
       - name: untracked file is detected as changed
         run: |
           tmpdir=$(mktemp -d)
+          trap 'rm -rf "${tmpdir}"' EXIT
           cd "${tmpdir}"
           git init
           git config user.name test


### PR DESCRIPTION
## Summary

- Add `trap 'rm -rf "${tmpdir}"' EXIT` immediately after each `tmpdir=$(mktemp -d)` in the three diff-detection test steps in `.github/workflows/main.yml`
- Without a trap, a `set -e` failure inside the step leaves the temp directory on disk (relevant for self-hosted runners and local `act` runs)
- `action.yml` already has this pattern (added in commit `4260fa0`); this PR brings the workflow tests in line

## Test plan

- [ ] CI passes (shell-format, shell-lint, diff-detection on ubuntu and macos, example)
- [ ] `actionlint` and `shellcheck` pass locally (already verified before pushing)