### PR TITLE
Tighten release version regex matching

### DIFF
--- a/.github/workflows/prepare-release-update.yml
+++ b/.github/workflows/prepare-release-update.yml
@@ -77,8 +77,8 @@ jobs:
       - name: Download bundled release artifact
         run: |
           set -euo pipefail
-          version="$(grep -Eo 'version=v[0-9][0-9.]*' action.yml | head -n1 | cut -d= -f2)"
-          target="$(grep -Eo 'gitignore-in-x86_64-unknown-linux-gnu-v[0-9][0-9.]*\.tar\.gz' action.yml | head -n1)"
+          version="$(grep -E '^[[:space:]]*version=v[0-9]+\.[0-9]+\.[0-9]+$' action.yml | head -n1 | cut -d= -f2)"
+          target="gitignore-in-x86_64-unknown-linux-gnu-${version}.tar.gz"
           url="https://github.com/gitignore-in/gitignore-in/releases/download/${version}/${target}"
           echo "Downloading ${url}" >&2
           wget --tries=3 --timeout=60 "${url}"

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -65,8 +65,8 @@ done
 # Stage the action.yml rewrite next to the new checksum file. We only swap
 # both into the repo after they have both been produced successfully.
 staging_action="${tmpdir}/action.yml"
-sed \
-	-e "s/version=v[0-9][0-9.]*$/version=${version}/" \
+sed -E \
+	-e "s/version=v[0-9]+\\.[0-9]+\\.[0-9]+$/version=${version}/" \
 	"${action_file}" >"${staging_action}"
 if ! grep -qE "^[[:space:]]*version=${version}\$" "${staging_action}"; then
 	echo "action.yml version= line did not update to ${version}" >&2


### PR DESCRIPTION
## Summary
- Match action version rewrites against a strict `vMAJOR.MINOR.PATCH` shape.
- Read the release version back from a full strict `version=` line in the release-preparation workflow.
- Build the Linux smoke-test artifact name from the validated version instead of scraping a loose tarball pattern.

## Verification
- `shellcheck scripts/*.sh`
- `shfmt -d scripts/*.sh`
- `actionlint -color`
- `typos .`
- strict semver smoke checks with `grep` and `sed`
- `git diff --check`
