### PR TITLE
Add Renovate manager for bundled binary version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,5 +2,19 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>kitsuyui/renovate-config"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^action\\.yml$/"
+      ],
+      "matchStrings": [
+        "version=(?<currentValue>v\\d+\\.\\d+\\.\\d+)\\n"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "gitignore-in/gitignore-in",
+      "versioningTemplate": "semver"
+    }
   ]
 }


### PR DESCRIPTION
Summary:
- Add a Renovate regex custom manager for the bundled gitignore-in binary version in action.yml.
- Track the version with the GitHub Releases datasource for gitignore-in/gitignore-in.

Verification:
- jq . .github/renovate.json5
- node -e '...' extraction check (confirmed currentValue v0.2.0)
- shellcheck scripts/*.sh
- actionlint -color
- shfmt -d scripts/*.sh
- typos
- git diff --check
- npx --yes -p renovate renovate-config-validator .github/renovate.json5
