### PR TITLE
ci: move GHA expressions out of run: blocks into env: variables

### DIFF
--- a/.github/workflows/prepare-release-update.yml
+++ b/.github/workflows/prepare-release-update.yml
@@ -69,10 +69,13 @@ jobs:
       - name: Verify released version exists
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release view "${{ needs.resolve.outputs.version }}" --repo gitignore-in/gitignore-in >/dev/null
+          RELEASE_VERSION: ${{ needs.resolve.outputs.version }}
+        run: gh release view "${RELEASE_VERSION}" --repo gitignore-in/gitignore-in >/dev/null
 
       - name: Update bundled gitignore.in version
-        run: ./scripts/update-version.sh "${{ needs.resolve.outputs.version }}"
+        env:
+          RELEASE_VERSION: ${{ needs.resolve.outputs.version }}
+        run: ./scripts/update-version.sh "${RELEASE_VERSION}"
 
       - name: Download bundled release artifact
         run: |
@@ -102,7 +105,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Update bundled gitignore.in version
-        run: ./scripts/update-version.sh "${{ needs.resolve.outputs.version }}"
+        env:
+          RELEASE_VERSION: ${{ needs.resolve.outputs.version }}
+        run: ./scripts/update-version.sh "${RELEASE_VERSION}"
 
       - name: Create update pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8

--- a/action.yml
+++ b/action.yml
@@ -102,7 +102,7 @@ runs:
         url="https://github.com/gitignore-in/gitignore-in/releases/download/${version}/${target}"
         echo "Downloading ${url} (${RUNNER_OS}-${RUNNER_ARCH})" >&2
         wget --tries=3 --timeout=60 "${url}"
-        grep -F "  ${target}" "${{ github.action_path }}/bundled-binary.sha256" > "${target}.sha256"
+        grep -F "  ${target}" "${GITHUB_ACTION_PATH}/bundled-binary.sha256" > "${target}.sha256"
         shasum -a 256 -c "${target}.sha256"
         tar -xzf "${target}"
         mkdir -p "${RUNNER_TEMP}/gitignore-in/bin"
@@ -131,7 +131,7 @@ runs:
     - name: check .gitignore
       id: check
       run: |
-        "${{ github.action_path }}/scripts/has-meaningful-gitignore-diff.sh" .gitignore
+        "${GITHUB_ACTION_PATH}/scripts/has-meaningful-gitignore-diff.sh" .gitignore
       shell: bash
       working-directory: repository
 


### PR DESCRIPTION
## Summary

Inline `${{ }}` expressions inside `run:` blocks are text-substituted directly into shell source before execution — a pattern flagged as script injection by GitHub's security hardening docs and `actionlint`.

**action.yml** (2 uses of `github.action_path` in `run:` blocks):
- Replaced with `${GITHUB_ACTION_PATH}`, the equivalent env var available in composite actions

**prepare-release-update.yml** (3 uses of `needs.resolve.outputs.version` in `run:` blocks):
- Added `env: RELEASE_VERSION: ${{ needs.resolve.outputs.version }}` to each step and replaced inline `"${{ ... }}"` with `"${RELEASE_VERSION}"`

`with:` block entries (`title:`, `body:`) are not shell-executed and are left as-is.

## Test plan

- [x] No `${{ }}` expressions remain in `run:` shell contexts
- [x] Behaviour is identical; only the binding path changes