### PR TITLE
Install bundled binary with executable mode before publishing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -106,8 +106,8 @@ runs:
         shasum -a 256 -c "${target}.sha256"
         tar -xzf "${target}"
         mkdir -p "${RUNNER_TEMP}/gitignore-in/bin"
-        cp gitignore.in "${RUNNER_TEMP}/gitignore-in/bin/gitignore.in"
-        chmod +x "${RUNNER_TEMP}/gitignore-in/bin/gitignore.in"
+        install -m 0755 gitignore.in "${tmpdir}/gitignore.in.installed"
+        mv "${tmpdir}/gitignore.in.installed" "${RUNNER_TEMP}/gitignore-in/bin/gitignore.in"
         echo "${RUNNER_TEMP}/gitignore-in/bin" >> "${GITHUB_PATH}"
       shell: bash
 


### PR DESCRIPTION
## Summary
- stage the downloaded gitignore.in binary with executable permissions before moving it into the runner bin directory
- replace the separate cp/chmod destination update with a prepared file followed by a single move

## Tests
- `bash -n scripts/update-version.sh scripts/has-meaningful-gitignore-diff.sh`
- parsed `action.yml` with Ruby YAML
- smoke-tested `install -m 0755` plus `mv` produces an executable file
- `./scripts/update-version.sh v0.2.1`
