### PR TITLE
Add boilerplates_ref input for reproducible .gitignore generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,3 +92,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./
+
+  example-pinned-boilerplates:
+    runs-on: ubuntu-latest
+    name: test (boilerplates_ref passthrough)
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./
+        with:
+          boilerplates_ref: main

--- a/README.md
+++ b/README.md
@@ -28,6 +28,29 @@ steps:
 - uses: gitignore-in/gh-action@main
 ```
 
+## Inputs
+
+| Input | Description | Default |
+|---|---|---|
+| `branch_name` | Branch name for the pull request | `gitignore-in` |
+| `base_branch` | Base branch for the pull request | `main` |
+| `commit_message` | Commit message for the `.gitignore` update | `Update .gitignore by gitignore.in` |
+| `pr_title` | Pull request title | `Update .gitignore` |
+| `pr_body` | Pull request body | `Update .gitignore by gitignore.in` |
+| `delete_branch` | Delete the branch after merge | `true` |
+| `boilerplates_ref` | Git ref (branch, tag, or SHA) of the [toptal/gitignore](https://github.com/toptal/gitignore) boilerplates database to pin. When set, every run produces identical `.gitignore` output for the same `.gitignore.in` template. Leave empty to always use the latest boilerplates (default, non-deterministic). | `""` |
+
+### Pinning the boilerplates database
+
+By default the action fetches the latest boilerplates database on every run.
+To produce reproducible `.gitignore` output, pass a specific commit SHA:
+
+```yaml
+- uses: gitignore-in/gh-action@main
+  with:
+    boilerplates_ref: "abc1234"  # SHA from github.com/toptal/gitignore
+```
+
 ## Maintenance
 
 To update the bundled `gitignore.in` release manually:

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,15 @@ inputs:
       Default: true
     required: false
     default: "true"
+  boilerplates_ref:
+    description: |
+      Optional git ref (branch, tag, or full SHA) for the gitignore boilerplates
+      database (github.com/toptal/gitignore). When set, the boilerplates database
+      is checked out at this ref after the update, making .gitignore generation
+      reproducible across runs. Leave empty to use the latest commit (default
+      behaviour, non-deterministic).
+    required: false
+    default: ""
 outputs:
   pull-request-number:
     description: Pull request number.
@@ -75,6 +84,8 @@ runs:
         path: repository
 
     - uses: gitignore-in/install-gibo@9e7dba9e59f184b41f542669b0864687a6f69b45 # v0.1.0
+      with:
+        boilerplates-ref: ${{ inputs.boilerplates_ref }}
     - run: |
         set -euo pipefail
         tmpdir=$(mktemp -d)


### PR DESCRIPTION
## Summary

The boilerplates database used by `gitignore.in` (`~/.gitignore-boilerplates`, sourced from [toptal/gitignore](https://github.com/toptal/gitignore)) was fetched at the latest commit on every run. This means two runs against the same `.gitignore.in` template could produce different `.gitignore` files if the upstream database changed between them.

`gitignore-in/install-gibo` already supports a `boilerplates-ref` input that pins the database to a specific commit. This PR exposes that capability as a new `boilerplates_ref` input on this action.

## Changes

- **`action.yml`**: add optional `boilerplates_ref` input (default `""`); pass it to `install-gibo`'s `boilerplates-ref` input
- **`.github/workflows/main.yml`**: add `example-pinned-boilerplates` smoke-test job that exercises `boilerplates_ref: main`
- **`README.md`**: document all inputs and add a pinning example

## Behaviour

| `boilerplates_ref` | Behaviour |
|---|---|
| `""` (default) | unchanged — latest boilerplates database (non-deterministic) |
| SHA / tag / branch | boilerplates checked out at that ref → reproducible output |

## Backward compatibility

No breaking change. The new input is optional with an empty-string default, so existing callers that do not set it continue to work exactly as before.

## Trade-offs

Callers that do not set `boilerplates_ref` remain non-deterministic. A future improvement could expose `boilerplates-commit` from `install-gibo` directly to make it easier for callers to record the ref actually used.
