### PR TITLE
Add timeout handling for gitignore-in execution

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,3 +101,25 @@ jobs:
       - uses: ./
         with:
           boilerplates_ref: main
+
+  timeout-helper:
+    runs-on: ubuntu-latest
+    name: timeout helper
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: preserves command exit status
+        run: |
+          set +e
+          scripts/run-with-timeout.sh 5 bash -c 'exit 7'
+          status=$?
+          set -e
+          [ "${status}" -eq 7 ]
+
+      - name: exits 124 when command exceeds timeout
+        run: |
+          set +e
+          scripts/run-with-timeout.sh 1 bash -c 'sleep 5'
+          status=$?
+          set -e
+          [ "${status}" -eq 124 ]

--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,8 @@ runs:
       shell: bash
 
     - name: run gitignore.in
-      run: gitignore.in
+      run: |
+        "${GITHUB_ACTION_PATH}/scripts/run-with-timeout.sh" 300 gitignore.in
       shell: bash
       working-directory: repository
 
@@ -132,7 +133,7 @@ runs:
       run: |
         boilerplates_dir="${HOME}/.gitignore-boilerplates"
         if [ -d "${boilerplates_dir}/.git" ]; then
-          ref=$(git -C "${boilerplates_dir}" rev-parse HEAD 2>/dev/null || echo "")
+          ref=$(git -C "${boilerplates_dir}" rev-parse --verify HEAD)
         else
           ref=""
         fi

--- a/scripts/run-with-timeout.sh
+++ b/scripts/run-with-timeout.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+timeout_seconds="${1:-}"
+if [ -z "${timeout_seconds}" ] || ! [[ "${timeout_seconds}" =~ ^[0-9]+$ ]] || [ "${timeout_seconds}" -eq 0 ]; then
+	echo "usage: $0 <positive-timeout-seconds> <command> [args...]" >&2
+	exit 2
+fi
+shift
+
+if [ "$#" -eq 0 ]; then
+	echo "usage: $0 <positive-timeout-seconds> <command> [args...]" >&2
+	exit 2
+fi
+
+command_display="$*"
+tmpdir="$(mktemp -d)"
+timeout_marker="${tmpdir}/timed-out"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+"$@" &
+command_pid=$!
+
+(
+	sleep "${timeout_seconds}"
+	if kill -0 "${command_pid}" 2>/dev/null; then
+		printf 'command timed out after %ss: %s\n' "${timeout_seconds}" "${command_display}" >&2
+		: >"${timeout_marker}"
+		kill "${command_pid}" 2>/dev/null || true
+	fi
+) &
+watchdog_pid=$!
+
+set +e
+wait "${command_pid}" 2>/dev/null
+status=$?
+set -e
+
+kill "${watchdog_pid}" 2>/dev/null || true
+wait "${watchdog_pid}" 2>/dev/null || true
+
+if [ -f "${timeout_marker}" ]; then
+	exit 124
+fi
+
+exit "${status}"


### PR DESCRIPTION
## Summary

- run `gitignore.in` through a small timeout helper so a hung binary fails before the job-level timeout
- stop hiding `git rev-parse` failures when capturing the boilerplates database ref
- add workflow coverage for the timeout helper's exit-code behavior

## Verification

- `shfmt -d scripts/*.sh`
- `shellcheck scripts/*.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `typos .`
- timeout helper local checks for exit status preservation and timeout exit 124
