### PR TITLE
Fix whitespace-only .gitignore diff not being filtered

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,22 @@ jobs:
           "${GITHUB_WORKSPACE}/scripts/has-meaningful-gitignore-diff.sh" .gitignore
           grep '^changed=false$' "${GITHUB_OUTPUT}"
 
+      - name: whitespace-only diff is ignored
+        run: |
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "${tmpdir}"' EXIT
+          cp .gitignore "${tmpdir}/.gitignore"
+          cd "${tmpdir}"
+          git init
+          git config user.name test
+          git config user.email test@example.com
+          git add .gitignore
+          git commit -m init
+          printf '\n   \n\t\n' >> .gitignore
+          export GITHUB_OUTPUT="${tmpdir}/output.txt"
+          "${GITHUB_WORKSPACE}/scripts/has-meaningful-gitignore-diff.sh" .gitignore
+          grep '^changed=false$' "${GITHUB_OUTPUT}"
+
       - name: meaningful diff is detected
         run: |
           tmpdir=$(mktemp -d)

--- a/scripts/has-meaningful-gitignore-diff.sh
+++ b/scripts/has-meaningful-gitignore-diff.sh
@@ -16,7 +16,7 @@ fi
 
 if git diff -- "${target}" |
 	grep '^[+-][^+-]' |
-	grep -vq -e '^[+-][[:space:]]*#' -e '^$'; then
+	grep -vq -e '^[+-][[:space:]]*#' -e '^[+-][[:space:]]*$'; then
 	echo "changed=true" >>"${GITHUB_OUTPUT:-/dev/stdout}"
 else
 	echo "changed=false" >>"${GITHUB_OUTPUT:-/dev/stdout}"


### PR DESCRIPTION
The `'^$'` pattern in the second `grep -vq` of `has-meaningful-gitignore-diff.sh` was dead code.
The preceding `grep '^[+-][^+-]'` requires at least one non-`+-` character after `+`/`-`, so empty lines (`'^$'`) can never reach the second filter.
As a result, diff lines consisting of only whitespace (e.g., `+ `) were not filtered and incorrectly caused `changed=true`.

Replace `'^$'` with `'^[+-][[:space:]]*$'` to correctly exclude whitespace-only lines.
Add a CI test step that verifies whitespace-only additions to `.gitignore` are treated as `changed=false`.
