### PR TITLE
Ignore final-newline-only gitignore diffs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,22 @@ jobs:
           "${GITHUB_WORKSPACE}/scripts/has-meaningful-gitignore-diff.sh" .gitignore
           grep '^changed=false$' "${GITHUB_OUTPUT}"
 
+      - name: missing final newline diff is ignored
+        run: |
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "${tmpdir}"' EXIT
+          cd "${tmpdir}"
+          git init
+          git config user.name test
+          git config user.email test@example.com
+          printf 'node_modules/' > .gitignore
+          git add .gitignore
+          git commit -m init
+          printf 'node_modules/\n' > .gitignore
+          export GITHUB_OUTPUT="${tmpdir}/output.txt"
+          "${GITHUB_WORKSPACE}/scripts/has-meaningful-gitignore-diff.sh" .gitignore
+          grep '^changed=false$' "${GITHUB_OUTPUT}"
+
       - name: meaningful diff is detected
         run: |
           tmpdir=$(mktemp -d)

--- a/scripts/has-meaningful-gitignore-diff.sh
+++ b/scripts/has-meaningful-gitignore-diff.sh
@@ -14,7 +14,7 @@ if ! git diff --name-only -- "${target}" | grep -q .; then
 	exit 0
 fi
 
-if git diff -- "${target}" |
+if git diff --ignore-space-at-eol -- "${target}" |
 	grep '^[+-][^+-]' |
 	grep -vq -e '^[+-][[:space:]]*#' -e '^[+-][[:space:]]*$'; then
 	echo "changed=true" >>"${GITHUB_OUTPUT:-/dev/stdout}"


### PR DESCRIPTION
## Summary
- Treat final-newline-only changes as non-meaningful when checking generated `.gitignore` diffs.
- Add a diff-detection fixture covering a file that only gains its missing final newline.

## Verification
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `shellcheck scripts/*.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- Manual diff-detection fixtures: comment-only, whitespace-only, missing final newline, meaningful content, untracked file
- `git diff --check`