### PR TITLE
Detect plus-minus-prefixed gitignore diffs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,6 +105,22 @@ jobs:
           "${GITHUB_WORKSPACE}/scripts/has-meaningful-gitignore-diff.sh" .gitignore
           grep '^changed=true$' "${GITHUB_OUTPUT}"
 
+      - name: plus-minus-prefixed meaningful diff is detected
+        run: |
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "${tmpdir}"' EXIT
+          cp .gitignore "${tmpdir}/.gitignore"
+          cd "${tmpdir}"
+          git init
+          git config user.name test
+          git config user.email test@example.com
+          git add .gitignore
+          git commit -m init
+          printf '\n+cache/\n-build/\n' >> .gitignore
+          export GITHUB_OUTPUT="${tmpdir}/output.txt"
+          "${GITHUB_WORKSPACE}/scripts/has-meaningful-gitignore-diff.sh" .gitignore
+          grep '^changed=true$' "${GITHUB_OUTPUT}"
+
       - name: untracked file is detected as changed
         run: |
           tmpdir=$(mktemp -d)

--- a/scripts/has-meaningful-gitignore-diff.sh
+++ b/scripts/has-meaningful-gitignore-diff.sh
@@ -15,8 +15,17 @@ if ! git diff --name-only -- "${target}" | grep -q .; then
 fi
 
 if git diff --ignore-space-at-eol -- "${target}" |
-	grep '^[+-][^+-]' |
-	grep -vq -e '^[+-][[:space:]]*#' -e '^[+-][[:space:]]*$'; then
+	awk '
+		/^diff --git / { in_hunk = 0; next }
+		/^@@ / { in_hunk = 1; next }
+		in_hunk && /^[+-]/ {
+			content = substr($0, 2)
+			if (content !~ /^[[:space:]]*(#|$)/) {
+				found = 1
+			}
+		}
+		END { exit found ? 0 : 1 }
+	'; then
 	echo "changed=true" >>"${GITHUB_OUTPUT:-/dev/stdout}"
 else
 	echo "changed=false" >>"${GITHUB_OUTPUT:-/dev/stdout}"


### PR DESCRIPTION
## Summary
- parse changed lines only inside unified diff hunks instead of filtering by the second diff character
- treat `.gitignore` rules that begin with `+` or `-` as meaningful changes
- add regression coverage for plus/minus-prefixed patterns in the diff-detection workflow

## Validation
- `shfmt -d scripts/*.sh`
- `shellcheck scripts/*.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- local diff-detection cases for comment-only, whitespace-only, missing-final-newline, ordinary meaningful, plus/minus-prefixed, and untracked `.gitignore` changes
