### PR TITLE
fix: commit bundled-binary.sha256 before action.yml to reduce partial-failure risk

### DIFF
--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -73,5 +73,5 @@ if ! grep -qE "^[[:space:]]*version=${version}\$" "${staging_action}"; then
 	exit 1
 fi
 
-mv "${staging_action}" "${action_file}"
 mv "${staging_file}" "${checksum_file}"
+mv "${staging_action}" "${action_file}"


### PR DESCRIPTION
## Summary

Reverse the order of the two `mv` operations at the end of
`scripts/update-version.sh` so that `bundled-binary.sha256` is committed
to the repository before `action.yml`.

## Why

The script builds both `action.yml` and `bundled-binary.sha256` in a
temporary directory first, then moves them into the repository with two
separate `mv` calls. If the process is interrupted (SIGTERM, disk full,
etc.) between the two calls, the repository is left in an inconsistent
state.

With the **original order** (`action.yml` first):

- `action.yml` references the *new* version
- `bundled-binary.sha256` still carries the *old* checksums
- Consumer workflows download the new binary but verify against old
  checksums → sha256 mismatch

With the **new order** (`bundled-binary.sha256` first):

- `bundled-binary.sha256` carries the *new* checksums
- `action.yml` still references the *old* version
- Consumer workflows download the old binary and verify against new
  checksums → sha256 mismatch

Both failure modes produce a visible sha256 mismatch. The new order is
preferable because `action.yml` remains consistent with the version it
was pinned to before the update started. The partial-failure state is
easier to diagnose: the version number in `action.yml` is the last
successfully released version, not a version that was never fully
deployed.

## Changed files

- `scripts/update-version.sh` — swap the order of the two `mv` lines

## Verification

- `shfmt -d scripts/*.sh` — no diff
- `shellcheck scripts/*.sh` — no issues
- `actionlint` — no issues

## Trade-offs

This does not eliminate the two-call race; it only changes which
inconsistency state is reachable on partial failure. True atomicity for
two independent files requires a higher-level mechanism (e.g., a git
commit). That change is out of scope for this minimal fix.
