### PR TITLE
Validate boilerplates ref before writing outputs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,40 @@ jobs:
       - name: action.yml and bundled-binary.sha256 are coherent
         run: scripts/check-version-sha256-coherence.sh
 
+  output-safety:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: boilerplates ref output accepts commit hashes
+        run: |
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "${tmpdir}"' EXIT
+          mkdir -p "${tmpdir}/bin" "${tmpdir}/boilerplates/.git"
+          cat >"${tmpdir}/bin/git" <<'SH'
+          #!/usr/bin/env sh
+          printf '0123456789abcdef0123456789abcdef01234567\n'
+          SH
+          chmod +x "${tmpdir}/bin/git"
+          PATH="${tmpdir}/bin:${PATH}" GITHUB_OUTPUT="${tmpdir}/output.txt" \
+            scripts/capture-boilerplates-ref.sh "${tmpdir}/boilerplates"
+          grep '^boilerplates-ref=0123456789abcdef0123456789abcdef01234567$' "${tmpdir}/output.txt"
+
+      - name: malformed boilerplates ref cannot inject outputs
+        run: |
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "${tmpdir}"' EXIT
+          mkdir -p "${tmpdir}/bin" "${tmpdir}/boilerplates/.git"
+          cat >"${tmpdir}/bin/git" <<'SH'
+          #!/usr/bin/env sh
+          printf '0123456789abcdef0123456789abcdef01234567\ninjected=true\n'
+          SH
+          chmod +x "${tmpdir}/bin/git"
+          PATH="${tmpdir}/bin:${PATH}" GITHUB_OUTPUT="${tmpdir}/output.txt" \
+            scripts/capture-boilerplates-ref.sh "${tmpdir}/boilerplates"
+          grep '^boilerplates-ref=$' "${tmpdir}/output.txt"
+          ! grep '^injected=true$' "${tmpdir}/output.txt"
+
   diff-detection:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,40 +78,6 @@ jobs:
       - name: action.yml and bundled-binary.sha256 are coherent
         run: scripts/check-version-sha256-coherence.sh
 
-  output-safety:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: boilerplates ref output accepts commit hashes
-        run: |
-          tmpdir=$(mktemp -d)
-          trap 'rm -rf "${tmpdir}"' EXIT
-          mkdir -p "${tmpdir}/bin" "${tmpdir}/boilerplates/.git"
-          cat >"${tmpdir}/bin/git" <<'SH'
-          #!/usr/bin/env sh
-          printf '0123456789abcdef0123456789abcdef01234567\n'
-          SH
-          chmod +x "${tmpdir}/bin/git"
-          PATH="${tmpdir}/bin:${PATH}" GITHUB_OUTPUT="${tmpdir}/output.txt" \
-            scripts/capture-boilerplates-ref.sh "${tmpdir}/boilerplates"
-          grep '^boilerplates-ref=0123456789abcdef0123456789abcdef01234567$' "${tmpdir}/output.txt"
-
-      - name: malformed boilerplates ref cannot inject outputs
-        run: |
-          tmpdir=$(mktemp -d)
-          trap 'rm -rf "${tmpdir}"' EXIT
-          mkdir -p "${tmpdir}/bin" "${tmpdir}/boilerplates/.git"
-          cat >"${tmpdir}/bin/git" <<'SH'
-          #!/usr/bin/env sh
-          printf '0123456789abcdef0123456789abcdef01234567\ninjected=true\n'
-          SH
-          chmod +x "${tmpdir}/bin/git"
-          PATH="${tmpdir}/bin:${PATH}" GITHUB_OUTPUT="${tmpdir}/output.txt" \
-            scripts/capture-boilerplates-ref.sh "${tmpdir}/boilerplates"
-          grep '^boilerplates-ref=$' "${tmpdir}/output.txt"
-          ! grep '^injected=true$' "${tmpdir}/output.txt"
-
   diff-detection:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/action.yml
+++ b/action.yml
@@ -186,13 +186,7 @@ runs:
     - name: capture boilerplates ref
       id: boilerplates_ref
       run: |
-        boilerplates_dir="${HOME}/.gitignore-boilerplates"
-        if [ -d "${boilerplates_dir}/.git" ]; then
-          ref=$(git -C "${boilerplates_dir}" rev-parse --verify HEAD)
-        else
-          ref=""
-        fi
-        echo "boilerplates-ref=${ref}" >> "${GITHUB_OUTPUT}"
+        "${GITHUB_ACTION_PATH}/scripts/capture-boilerplates-ref.sh"
       shell: bash
 
     - name: check .gitignore

--- a/scripts/capture-boilerplates-ref.sh
+++ b/scripts/capture-boilerplates-ref.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+boilerplates_dir="${1:-${HOME}/.gitignore-boilerplates}"
+ref=""
+
+if [ -d "${boilerplates_dir}/.git" ]; then
+	ref="$(git -C "${boilerplates_dir}" rev-parse --verify HEAD)"
+	if ! [[ "${ref}" =~ ^([0-9a-f]{40}|[0-9a-f]{64})$ ]]; then
+		echo "Unexpected boilerplates HEAD ref; leaving boilerplates-ref empty" >&2
+		ref=""
+	fi
+fi
+
+printf 'boilerplates-ref=%s\n' "${ref}" >>"${GITHUB_OUTPUT:-/dev/stdout}"


### PR DESCRIPTION
## Summary
- Move boilerplates ref output capture into a small helper script.
- Only write a 40- or 64-character hex commit id to `GITHUB_OUTPUT`.
- Add workflow checks for valid and malformed ref output.

## Checks
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `bash -n scripts/*.sh`
- `shellcheck scripts/*.sh`
- helper script valid/malformed output checks
- `git diff --check`
