### PR TITLE
Document bundled release update flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,22 @@ To produce reproducible `.gitignore` output, pass a specific commit SHA:
 
 ## Maintenance
 
-To update the bundled `gitignore.in` release manually:
+The action downloads the bundled `gitignore.in` release version declared in
+`action.yml`, and verifies each platform artifact with `bundled-binary.sha256`.
+
+When `gitignore-in/gitignore-in` publishes a new release, the
+`prepare action release update` workflow can prepare the version bump pull
+request. To update the bundled release manually instead, run:
 
 ```bash
-./scripts/update-version.sh v0.2.0
+./scripts/update-version.sh v0.2.1
 ```
 
 To rehearse the release-preparation workflow without opening a PR, run
 `prepare action release update` with `mode=dry-run`.
 The workflow accepts `vMAJOR.MINOR.PATCH` release tags and verifies the
-corresponding `gitignore-in/gitignore-in` release before updating `action.yml`.
+corresponding `gitignore-in/gitignore-in` release before updating `action.yml`
+and `bundled-binary.sha256`.
 
 See [Operational state machines](docs/state-machines.md) for the pull request,
 draft release, release update, and workflow concurrency boundaries that govern


### PR DESCRIPTION
Summary:
- Document that `action.yml` declares the bundled `gitignore.in` release version.
- Mention that platform artifacts are verified with `bundled-binary.sha256`.
- Update the manual maintenance command to the current bundled release and clarify that the update flow refreshes both `action.yml` and checksums.

Verification:
- `typos`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color=false`
- `bash -n scripts/*.sh`
- `shellcheck scripts/*.sh`
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `git diff --check`
