### PR TITLE
Align dependency update anchors

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,17 @@
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "gitignore-in/gitignore-in",
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/.*\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "go run (?<depName>mvdan\\.cc/sh/v3)/cmd/shfmt@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "go",
+      "versioningTemplate": "semver"
     }
   ]
 }

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Check spelling
-        uses: crate-ci/typos@7b04f660f4ee4f048d18fd341887cf28dfbedfe2 # master
+        uses: crate-ci/typos@f8a58b6b53f2279f71eb605f03a4ae4d10608f45 # v1.47.0
         # typos is a Source code spell checker
         # https://github.com/crate-ci/typos


### PR DESCRIPTION
## Summary
- Update `.github/workflows/spellcheck.yml` so the pinned `crate-ci/typos` action follows a tagged release anchor instead of the `master` branch anchor.
- Add a `.github/renovate.json5` regex manager for the workflow `shfmt` Go module version used by the inline `go run` command.

## Verification
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `shellcheck scripts/*.sh`
- `typos`
- `npx --yes --package renovate renovate-config-validator .github/renovate.json5`
