### PR TITLE
docs: add Outputs section, version pin guidance, and update bundled version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ steps:
 - uses: gitignore-in/gh-action@main
 ```
 
+For production use, pin to a specific tag or SHA to avoid unexpected changes:
+
+```yaml
+steps:
+- uses: actions/checkout@v4
+- uses: gitignore-in/gh-action@v0.2.3  # or pin to a full SHA
+```
+
 ## Inputs
 
 | Input | Description | Default |
@@ -51,12 +59,31 @@ To produce reproducible `.gitignore` output, pass a specific commit SHA:
     boilerplates_ref: "abc1234"  # SHA from github.com/toptal/gitignore
 ```
 
+## Outputs
+
+| Output | Description |
+|---|---|
+| `pull-request-number` | Pull request number (empty when no PR was created or updated) |
+| `pull-request-url` | Pull request URL |
+| `pull-request-operation` | Operation performed: `created`, `updated`, or `closed` |
+| `pull-request-head-sha` | SHA of the head commit of the pull request |
+| `boilerplates-ref` | Commit SHA of the boilerplates database used; empty string if unavailable |
+
+Example — notify on new PR:
+
+```yaml
+- uses: gitignore-in/gh-action@main
+  id: gitignore
+- if: steps.gitignore.outputs.pull-request-operation == 'created'
+  run: echo "New PR ${{ steps.gitignore.outputs.pull-request-url }}"
+```
+
 ## Maintenance
 
 To update the bundled `gitignore.in` release manually:
 
 ```bash
-./scripts/update-version.sh v0.2.0
+./scripts/update-version.sh v0.2.1
 ```
 
 To rehearse the release-preparation workflow without opening a PR, run


### PR DESCRIPTION
## Summary

The README had an Inputs table but was missing several contract-level details
that action consumers need:

- **Outputs table**: document all five outputs (`pull-request-number`,
  `pull-request-url`, `pull-request-operation`, `pull-request-head-sha`,
  `boilerplates-ref`) with descriptions and an example that reads
  `steps.<id>.outputs.*`
- **Version pin guidance**: add a note in the Usage section recommending a
  tag or full SHA instead of `@main` for production workflows
- **Stale version in Maintenance**: update the `update-version.sh` command
  example from `v0.2.0` to `v0.2.1` to match the version currently bundled
  in `action.yml`

**Changed file:** `README.md`

## Verification

- `actionlint` passes with no issues
- `shellcheck scripts/*.sh` passes with no issues
- No Japanese characters introduced (public English repo)
