### PR TITLE
fix(timeout): kill process group and add SIGKILL fallback on timeout

### DIFF
--- a/scripts/run-with-timeout.sh
+++ b/scripts/run-with-timeout.sh
@@ -18,7 +18,15 @@ tmpdir="$(mktemp -d)"
 timeout_marker="${tmpdir}/timed-out"
 trap 'rm -rf "${tmpdir}"' EXIT
 
-"$@" &
+# setsid(1) places the command in a new session so that killing the process
+# group (kill -- -$pid) reaches the command and all its descendants.
+# On platforms where setsid is unavailable (e.g. macOS), fall back to starting
+# the command directly; in that case only the top-level PID is signalled.
+if command -v setsid >/dev/null 2>&1; then
+	setsid "$@" &
+else
+	"$@" &
+fi
 command_pid=$!
 
 (
@@ -26,7 +34,13 @@ command_pid=$!
 	if kill -0 "${command_pid}" 2>/dev/null; then
 		printf 'command timed out after %ss: %s\n' "${timeout_seconds}" "${command_display}" >&2
 		: >"${timeout_marker}"
-		kill "${command_pid}" 2>/dev/null || true
+		# Signal the whole process group first; fall back to the direct PID.
+		kill -- -"${command_pid}" 2>/dev/null || kill "${command_pid}" 2>/dev/null || true
+		# SIGKILL fallback: give the process up to 5 s to exit gracefully.
+		sleep 5
+		if kill -0 "${command_pid}" 2>/dev/null; then
+			kill -9 -- -"${command_pid}" 2>/dev/null || kill -9 "${command_pid}" 2>/dev/null || true
+		fi
 	fi
 ) &
 watchdog_pid=$!


### PR DESCRIPTION
## Summary

- Use `setsid(1)` to place the spawned command in its own session, so that a timeout sends `SIGTERM` to the entire process group (command + all descendants) rather than just the top-level PID.
- Add a 5-second `SIGKILL` fallback so commands that trap or ignore `SIGTERM` are also guaranteed to stop.

## Motivation

The previous implementation sent `SIGTERM` only to `$command_pid`.  If `gitignore.in` spawned child processes (e.g. `gibo`), those children would survive the timeout and continue consuming runner resources or writing to the output file after the action step had already exited with code 124.  Commands that ignore `SIGTERM` were similarly unaffected.

GNU `timeout` addresses both issues (process group kill + SIGKILL fallback); this change brings the hand-rolled wrapper up to the same contract.

## Platform behaviour

| Platform | `setsid` available | Effect |
|---|---|---|
| Linux (GitHub-hosted runner) | yes | full process group kill + SIGKILL fallback |
| macOS runner | no | graceful degradation: direct PID only (original behaviour) + SIGKILL fallback |

## Verification

- `shellcheck scripts/*.sh` — no findings
- `shfmt -w scripts/*.sh` — no changes
- `actionlint` — no findings