### PR TITLE
fix: use literal string match to verify version line in update-version.sh

### DIFF
--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -68,7 +68,7 @@ staging_action="${tmpdir}/action.yml"
 sed -E \
 	-e "s/version=v[0-9]+\\.[0-9]+\\.[0-9]+$/version=${version}/" \
 	"${action_file}" >"${staging_action}"
-if ! grep -qE "^[[:space:]]*version=${version}\$" "${staging_action}"; then
+if ! grep -qF "version=${version}" "${staging_action}"; then
 	echo "action.yml version= line did not update to ${version}" >&2
 	exit 1
 fi


### PR DESCRIPTION
## Summary

Use `grep -qF` (fixed-string) instead of `grep -qE` (extended regex) when verifying that `sed` updated the version line in `action.yml`.

The old pattern passed `${version}` (e.g. `v0.2.1`) directly as an ERE, where `.` matches any character. A corrupted replacement like `v0X2Y1` would have silently passed the guard. With `-F`, the comparison is a literal substring match, which is what the guard actually intends.

## Changes

- `scripts/update-version.sh`: replace `grep -qE "^[[:space:]]*version=${version}\$"` with `grep -qF "version=${version}"`

## Verification

- `shfmt -d scripts/*.sh`: no diff
- `shellcheck scripts/*.sh`: no findings
- `actionlint`: no findings

## Trade-offs

The anchors (`^[[:space:]]*` and `$`) are dropped, so the check becomes a substring match rather than a line-anchored match. In practice the `version=vX.Y.Z` pattern is specific enough that a false positive from another line is not realistic, and this matches the style already used in the file (see the `grep -cF` on the sha256 check above).
