### PR TITLE
fix(timeout): avoid false timeout marker after normal exit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,3 +175,31 @@ jobs:
           status=$?
           set -e
           [ "${status}" -eq 124 ]
+
+      - name: preserves normal exit when command finishes during timeout race
+        run: |
+          probe=$(mktemp)
+          rm -f "${probe}"
+          trap 'rm -f "${probe}"' EXIT
+
+          kill() {
+            if [ "${1:-}" = "-0" ] && [ -n "${RUN_WITH_TIMEOUT_RACE_PROBE:-}" ]; then
+              builtin kill "$@"
+              result=$?
+              if [ "${result}" -eq 0 ]; then
+                : > "${RUN_WITH_TIMEOUT_RACE_PROBE}"
+                sleep 0.2
+              fi
+              return "${result}"
+            fi
+
+            builtin kill "$@"
+          }
+          export -f kill
+          export RUN_WITH_TIMEOUT_RACE_PROBE="${probe}"
+
+          set +e
+          scripts/run-with-timeout.sh 1 bash -c "while [ ! -f \"\${RUN_WITH_TIMEOUT_RACE_PROBE}\" ]; do sleep 0.01; done; exit 0"
+          status=$?
+          set -e
+          [ "${status}" -eq 0 ]

--- a/scripts/run-with-timeout.sh
+++ b/scripts/run-with-timeout.sh
@@ -32,14 +32,15 @@ command_pid=$!
 (
 	sleep "${timeout_seconds}"
 	if kill -0 "${command_pid}" 2>/dev/null; then
-		printf 'command timed out after %ss: %s\n' "${timeout_seconds}" "${command_display}" >&2
-		: >"${timeout_marker}"
 		# Signal the whole process group first; fall back to the direct PID.
-		kill -- -"${command_pid}" 2>/dev/null || kill "${command_pid}" 2>/dev/null || true
-		# SIGKILL fallback: give the process up to 5 s to exit gracefully.
-		sleep 5
-		if kill -0 "${command_pid}" 2>/dev/null; then
-			kill -9 -- -"${command_pid}" 2>/dev/null || kill -9 "${command_pid}" 2>/dev/null || true
+		if kill -- -"${command_pid}" 2>/dev/null || kill "${command_pid}" 2>/dev/null; then
+			printf 'command timed out after %ss: %s\n' "${timeout_seconds}" "${command_display}" >&2
+			: >"${timeout_marker}"
+			# SIGKILL fallback: give the process up to 5 s to exit gracefully.
+			sleep 5
+			if kill -0 "${command_pid}" 2>/dev/null; then
+				kill -9 -- -"${command_pid}" 2>/dev/null || kill -9 "${command_pid}" 2>/dev/null || true
+			fi
 		fi
 	fi
 ) &


### PR DESCRIPTION
## Summary
- create the timeout marker only after the watchdog successfully signals the wrapped command or process group
- add deterministic workflow coverage for the normal-exit race between the liveness probe and the timeout signal

## Dependency
- Stacks on #61 because both changes update `scripts/run-with-timeout.sh`.

## Verification
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `shellcheck scripts/*.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `typos`
- `bash -n scripts/*.sh`
- `git diff --check`
- timeout helper snippets for exit 7, timeout 124, and the normal-exit race
