### PR TITLE
add timeout-minutes to all workflow jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   shell-format:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -23,6 +24,7 @@ jobs:
 
   shell-lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -37,6 +39,7 @@ jobs:
 
   diff-detection:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       matrix:
         os:
@@ -140,6 +143,7 @@ jobs:
 
   example:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     name: test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -147,6 +151,7 @@ jobs:
 
   example-pinned-boilerplates:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     name: test (boilerplates_ref passthrough)
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -156,6 +161,7 @@ jobs:
 
   timeout-helper:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     name: timeout helper
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/prepare-draft-release.yml
+++ b/.github/workflows/prepare-draft-release.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   draft-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/prepare-release-update.yml
+++ b/.github/workflows/prepare-release-update.yml
@@ -29,6 +29,7 @@ permissions:
 jobs:
   resolve:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       version: ${{ steps.resolve.outputs.version }}
       mode: ${{ steps.resolve.outputs.mode }}
@@ -66,6 +67,7 @@ jobs:
 
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: resolve
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -103,6 +105,7 @@ jobs:
 
   prepare-update:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [resolve, validate]
     if: ${{ needs.resolve.outputs.mode != 'dry-run' }}
     steps:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

Add `timeout-minutes` to all 11 workflow jobs across the four workflow files. Without an explicit timeout, GitHub Actions defaults to 360 minutes (6 hours), which means a hung job occupies a runner for up to 6 hours.

## Changes

| workflow | job | timeout-minutes |
| --- | --- | --- |
| `main.yml` | `shell-format` | 5 |
| `main.yml` | `shell-lint` | 5 |
| `main.yml` | `diff-detection` | 10 |
| `main.yml` | `example` | 15 |
| `main.yml` | `example-pinned-boilerplates` | 15 |
| `main.yml` | `timeout-helper` | 5 |
| `prepare-draft-release.yml` | `draft-release` | 15 |
| `prepare-release-update.yml` | `resolve` | 5 |
| `prepare-release-update.yml` | `validate` | 15 |
| `prepare-release-update.yml` | `prepare-update` | 10 |
| `spellcheck.yml` | `check` | 5 |

Timeout values are intentionally generous to avoid false failures while still bounding the worst-case hang duration well below the 360-minute default.

## Verification

- `actionlint` passes with no new findings
