### PR TITLE
track actionlint version in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,6 +26,17 @@
       ],
       "datasourceTemplate": "go",
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/.*\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "go run (?<depName>github\\.com/rhysd/actionlint)/cmd/actionlint@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "go",
+      "versioningTemplate": "semver"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add a Renovate `customManager` entry for `actionlint` so its `go run` pin in `main.yml` receives automated version-bump PRs, matching the existing setup for `shfmt`.

## Changes

`.github/renovate.json5`: add a second regex customManager targeting
`go run github.com/rhysd/actionlint/cmd/actionlint@<version>` in workflow files.

The `shfmt` entry and the new `actionlint` entry follow the same structure:
- `customType: regex`
- `datasourceTemplate: go`
- `versioningTemplate: semver`

## Verification

- `actionlint` passes with no new findings
