### PR TITLE
fix: detect 404 via HTTP status code instead of gh CLI error text

### DIFF
--- a/.github/workflows/prepare-draft-release.yml
+++ b/.github/workflows/prepare-draft-release.yml
@@ -59,22 +59,22 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          tmpdir="$(mktemp -d)"
-          trap 'rm -rf "${tmpdir}"' EXIT
 
           set +e
-          release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${VERSION}" 2>"${tmpdir}/release-error")"
+          response_with_headers="$(gh api --include "repos/${GITHUB_REPOSITORY}/releases/tags/${VERSION}")"
           status=$?
           set -e
 
           if [ "${status}" -ne 0 ]; then
-            if grep -q 'Not Found (HTTP 404)' "${tmpdir}/release-error"; then
+            http_status="$(printf '%s' "${response_with_headers}" | head -1 | tr -d '\r' | awk '{print $2}')"
+            if [ "${http_status}" = "404" ]; then
               exit 0
             fi
-            cat "${tmpdir}/release-error" >&2
+            printf '%s\n' "${response_with_headers}" >&2
             exit "${status}"
           fi
 
+          release_json="$(printf '%s' "${response_with_headers}" | sed '1,/^$/d')"
           is_draft="$(printf '%s' "${release_json}" | jq -r '.draft')"
           if [ "${is_draft}" = "true" ]; then
             exit 0


### PR DESCRIPTION
## Summary

The "Refuse to rewrite a published release" step detected a missing release (HTTP 404) by matching the string `Not Found (HTTP 404)` from `gh` CLI's stderr output. This text is an implementation detail of the `gh` CLI and is not a stable contract — the format has changed across `gh` versions and is not documented as a public API.

## Change

Replace the fragile stderr text match with `gh api --include`, which outputs the HTTP response status line to stdout. The 404 check now reads the numeric HTTP status code from the first line of the response headers — this is part of the HTTP protocol itself and is stable regardless of `gh` CLI version.

- Removed `tmpdir` (only used to buffer stderr; no longer needed)
- `gh api --include` captures headers + body together in stdout
- HTTP status is extracted with `head -1 | tr -d '\r' | awk '{print $2}'`
- JSON body is extracted with `sed '1,/^$/d'` (skip everything up to and including the blank line separator)

## Behavior

The observable behavior is unchanged: the step exits 0 (proceed) when the release does not exist, and exits 1 (refuse) when the release already exists and is published. The only difference is that 404 detection no longer depends on a human-readable error string.

## Verification

actionlint and shellcheck pass with no findings.
