### PR TITLE
remove Renovate custom manager for gitignore-in version tracking

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,18 +7,6 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^action\\.yml$/"
-      ],
-      "matchStrings": [
-        "version=(?<currentValue>v\\d+\\.\\d+\\.\\d+)\\n"
-      ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "gitignore-in/gitignore-in",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
         "/^\\.github/workflows/.*\\.ya?ml$/"
       ],
       "matchStrings": [


### PR DESCRIPTION
## Summary

Remove the Renovate custom regex manager that tracked `gitignore-in/gitignore-in`
releases in `action.yml`. That manager only updated the `version=vX.Y.Z` line and
left `bundled-binary.sha256` pointing at the previous release's checksums. When such
a PR was merged, the `shasum -a 256 -c` verification step in `action.yml` would fail
for every consumer workflow because the checksum file contained no entry for the new
version's tarballs.

## Why this manager is the wrong tool here

`action.yml` and `bundled-binary.sha256` must always be updated together.
`scripts/update-version.sh` already enforces this atomicity — it stages both files in a
tmpdir and only writes them to the repo after all four platform checksums have been
fetched and cross-checked. The intended trigger is `prepare-release-update.yml`, which
fires on `repository_dispatch: gitignore-in-release-published` (or `workflow_dispatch`)
and calls `update-version.sh` before opening a PR.

The Renovate manager created a second, partial update path that bypassed that
atomicity guarantee.

## Change

- **Removed**: `customManagers` entry with `depNameTemplate: "gitignore-in/gitignore-in"` and `managerFilePatterns: ["/^action\\.yml$/"]`
- **Kept**: `customManagers` entry tracking `mvdan.cc/sh/v3` (shfmt) in workflow files — unrelated and correct

## Verification

- `actionlint` and `shellcheck` pass with no findings
- The remaining Renovate manager (shfmt version tracking) is unaffected
- `prepare-release-update.yml` remains the sole path for updating `action.yml` + `bundled-binary.sha256`
