### PR TITLE
docs: document supported runner platforms in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ gibo dump Windows
 echo "node_modules/"
 ```
 
+> **Note:** `gibo dump Windows` above is a `.gitignore` template example — it fetches Windows-specific ignore patterns for the generated `.gitignore` file. It is unrelated to the runner platform this action runs on.
+
 ```
 $ gitignore-in
 Generated .gitignore
@@ -35,6 +37,18 @@ steps:
 - uses: actions/checkout@v4
 - uses: gitignore-in/gh-action@v0.2.3  # or pin to a full SHA
 ```
+
+## Supported platforms
+
+| Runner OS | Architecture | Supported |
+|---|---|---|
+| Linux | x64 (X64) | Yes |
+| Linux | ARM64 | Yes |
+| macOS | x64 (X64) | Yes |
+| macOS | ARM64 | Yes |
+| Windows | any | No |
+
+Windows and other platforms are not supported. The action exits with an error if run on an unsupported runner.
 
 ## Inputs
 


### PR DESCRIPTION
## Summary

Document the supported runner platforms in `README.md`.

- Add a `## Supported platforms` table listing Linux X64/ARM64 and macOS X64/ARM64 as supported, and Windows as not supported
- Add a clarifying note in the Example section explaining that `gibo dump Windows` in the `.gitignore.in` template example refers to generating Windows-specific gitignore patterns — it is unrelated to the runner platform the action runs on

## Motivation

The action explicitly fails on unsupported platforms (`echo "Unsupported runner platform" >&2; exit 1`), but this constraint was not documented in `README.md`. Users selecting the action from the GitHub Marketplace have no way to know Windows is unsupported without reading `action.yml` directly.

Additionally, the `gibo dump Windows` example near the top of the README could mislead users into thinking Windows runners are supported.

## Changes

- `README.md`: added `## Supported platforms` section and a clarifying note in the Example section

## Verification

- `shfmt` format check: passed (no shell script changes)
- `actionlint` + `shellcheck` lint: passed (no workflow/script changes)
- `typos` spellcheck: 0 findings
