### PR TITLE
Bound release artifact downloads in update-version.sh

### DIFF
--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -38,9 +38,20 @@ action_file="${repo_root}/action.yml"
 staging_file="${tmpdir}/bundled-binary.sha256"
 : >"${staging_file}"
 
+curl_connect_timeout_seconds=30
+curl_max_time_seconds=300
+
 for arch in "${archs[@]}"; do
 	target="gitignore-in-${arch}-${version}.tar.gz"
-	curl --fail --location --silent --show-error --output "${tmpdir}/${target}" "${release_url}/${target}"
+	curl \
+		--fail \
+		--location \
+		--silent \
+		--show-error \
+		--connect-timeout "${curl_connect_timeout_seconds}" \
+		--max-time "${curl_max_time_seconds}" \
+		--output "${tmpdir}/${target}" \
+		"${release_url}/${target}"
 	(cd "${tmpdir}" && shasum -a 256 "${target}") >>"${staging_file}"
 done
 


### PR DESCRIPTION
Summary
- Added connection and overall time limits to the release tarball curl invocation in scripts/update-version.sh.
- Kept the existing tempdir staging and atomic final mv flow intact.

Verification
- go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh
- shellcheck scripts/*.sh
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color
- bash -n scripts/*.sh
- git diff --check
