### PR TITLE
Restrict workflow permissions to per-job minimum

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,14 +6,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-
 jobs:
   shell-format:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -23,6 +20,8 @@ jobs:
 
   shell-lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -37,6 +36,8 @@ jobs:
 
   diff-detection:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os:
@@ -141,6 +142,9 @@ jobs:
   example:
     runs-on: ubuntu-latest
     name: test
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./
@@ -148,6 +152,9 @@ jobs:
   example-pinned-boilerplates:
     runs-on: ubuntu-latest
     name: test (boilerplates_ref passthrough)
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./
@@ -157,6 +164,8 @@ jobs:
   timeout-helper:
     runs-on: ubuntu-latest
     name: timeout helper
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 


### PR DESCRIPTION
The workflow previously declared `contents: write`, `pull-requests: write`,
and `issues: write` at the workflow level, causing all jobs to inherit these
permissions even though most of them only need read access.

- Lint and test jobs (`shell-format`, `shell-lint`, `diff-detection`,
  `timeout-helper`) now get `contents: read` only.
- The two example jobs that invoke the composite action and may create pull
  requests (`example`, `example-pinned-boilerplates`) keep `contents: write`
  and `pull-requests: write`.
- `issues: write` is removed entirely; no job uses it.

Trade-off: each job now requires an explicit `permissions` block. The upside
is that a compromised lint step cannot write to the repository or open pull
requests.
