### PR TITLE
Scope draft-release trigger to bundled-binary.sha256

### DIFF
--- a/.github/workflows/prepare-draft-release.yml
+++ b/.github/workflows/prepare-draft-release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - action.yml
+      - bundled-binary.sha256
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Summary

The `prepare-draft-release` workflow triggered on any push to `main` that touched `action.yml`. However, `action.yml` contains both the bundled binary version (`version=v0.2.1`) and three `uses:` SHA pins updated regularly by Renovate (`actions/checkout`, `gitignore-in/install-gibo`, `peter-evans/create-pull-request`). Each Renovate SHA-pin merge created a spurious draft release unrelated to a binary version bump.

## Change

Change the push trigger path from `action.yml` to `bundled-binary.sha256`. The `bundled-binary.sha256` file is only updated by `prepare-release-update.yml` when a new binary version is published, making it a precise semantic trigger for "bundled binary changed."

Renovate does not touch `bundled-binary.sha256`, so SHA-pin updates to `action.yml` no longer trigger draft release creation. Manual releases remain available via `workflow_dispatch`.

## Verification

- `actionlint` and `shellcheck`: pass
- `workflow_dispatch` trigger is unchanged — manual releases work as before
