### PR TITLE
fix(timeout): kill watchdog on SIGTERM/SIGINT to prevent orphan process

### DIFF
--- a/scripts/run-with-timeout.sh
+++ b/scripts/run-with-timeout.sh
@@ -30,6 +30,7 @@ command_pid=$!
 	fi
 ) &
 watchdog_pid=$!
+trap 'kill "${watchdog_pid}" 2>/dev/null || true; wait "${watchdog_pid}" 2>/dev/null || true' TERM INT
 
 set +e
 wait "${command_pid}" 2>/dev/null


### PR DESCRIPTION
## Summary

`scripts/run-with-timeout.sh` spawns a watchdog subshell (`watchdog_pid`) that monitors the command for timeout. When the script exits normally (command completes or times out), lines 40-41 kill and wait for the watchdog. However, if the parent script receives **SIGTERM** (e.g., a GitHub Actions job cancellation), `wait "${command_pid}"` is interrupted and execution jumps directly to the `EXIT` trap, bypassing the `kill`/`wait` block. The watchdog then runs as an orphan for up to `timeout_seconds` (currently 300 s).

## Fix

Add a `TERM`/`INT` trap immediately after `watchdog_pid` is assigned:

```sh
trap 'kill "${watchdog_pid}" 2>/dev/null || true; wait "${watchdog_pid}" 2>/dev/null || true' TERM INT
```

This ensures the watchdog is always reaped when the parent exits abnormally, mirroring the cleanup already performed on the normal-exit path.

## Verification

The existing `timeout-helper` tests in `main.yml` cover normal-exit and timeout paths. The new trap fires on the cancellation path which is not exercised by those tests, but the logic is the same `kill`/`wait` sequence already used on lines 40-41.