### PR TITLE
docs: add CONTRIBUTING.md and docs/RELEASE.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Thank you for your interest in contributing to gitignore-in/gh-action.
+
+## Reporting Issues
+
+Use [GitHub Issues](https://github.com/gitignore-in/gh-action/issues) to report bugs or suggest improvements.
+
+When reporting a bug, include:
+
+- What you expected to happen
+- What actually happened
+- The workflow YAML (or a minimal reproduction)
+- Runner OS and architecture
+- The action version you are using (`@main`, a tag, or a pinned SHA)
+
+For security vulnerabilities, open a [private security advisory](https://github.com/gitignore-in/gh-action/security/advisories/new) instead of a public issue.
+
+## Submitting Changes
+
+1. Fork the repository and create a topic branch from `main`.
+2. Keep changes focused — one logical change per pull request.
+3. Run the CI checks locally if possible; the `main.yml` workflow runs on pull requests.
+4. Open a pull request against `main` with a clear description of what changed and why.
+
+## Commit Messages
+
+Follow the format `prefix: short description` using one of:
+
+- `fix:` — bug fix
+- `feat:` — new capability
+- `docs:` — documentation only
+- `chore:` — maintenance (dependency bumps, script updates)
+- `ci:` — CI workflow changes
+
+## Reference Policy: `@main` vs Tags
+
+See [docs/RELEASE.md](docs/RELEASE.md#reference-policy-main-vs-tags) for guidance on which ref to use.
+
+## License
+
+By contributing, you agree that your changes will be released under the [MIT License](LICENSE).

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,75 @@
+# Release Governance
+
+This document describes how releases of the `gitignore-in/gh-action` action are governed,
+who is responsible for each step, and how automated workflows relate to human decisions.
+
+## Release lifecycle
+
+```
+action.yml merged to main
+        ↓
+prepare-draft-release workflow creates a draft GitHub release
+        ↓
+Maintainer reviews the draft release notes
+        ↓
+Maintainer publishes the draft release (manual step)
+        ↓
+Tag is live; consumers pinned to that tag receive the new version
+```
+
+### Publish decision (human step)
+
+After `prepare-draft-release` runs, a draft release accumulates automatically-generated
+release notes. A maintainer reviews the draft and clicks **Publish** in the GitHub
+Releases UI when the notes are accurate and the release is ready.
+
+There is no bot or workflow that publishes the release automatically.
+If a draft has been sitting for several days without publishing, the maintainer should
+either publish it, delete the draft, or update `action.yml` to reflect the intended
+next version.
+
+## Bundled binary update
+
+When `gitignore-in/gitignore-in` publishes a new release, the `prepare action release update`
+workflow can be triggered automatically via `repository_dispatch` from upstream,
+or manually via workflow dispatch.
+
+### Human responsibility
+
+The `prepare action release update` workflow opens a pull request. A maintainer must:
+
+1. Review the PR (version bump in `action.yml`, updated `bundled-binary.sha256`).
+2. Merge the PR after the CI checks pass.
+3. Verify that the bundled binary smoke test passed in the workflow run.
+
+If the upstream dispatch never arrives (upstream wiring not configured), trigger the
+workflow manually via the GitHub Actions UI or `gh workflow run`.
+
+### Cadence
+
+There is no hard cadence requirement. As a guideline, bundle updates should be merged
+within two weeks of a new upstream release. The
+[audit-bundled-binary-version-stale-001](https://github.com/kitsuyui/kimono-tasks)
+finding tracks version drift.
+
+## Reference policy: `@main` vs tags
+
+| Reference | When to use |
+|---|---|
+| `@main` | Development or testing — always picks up the latest bundled binary and workflow changes. May include breaking changes without notice. |
+| `@vMAJOR.MINOR.PATCH` | Production use — pinned to a known-good release. Recommended for stability. |
+| SHA pinning | Highest reproducibility — immune to tag rewrites. Use for security-sensitive workflows. |
+
+Semantic versioning intent:
+- **patch** (`v0.x.PATCH`): bug fixes, binary updates, documentation changes
+- **minor** (`v0.MINOR.0`): new inputs or outputs added in a backwards-compatible way
+- **major** (`vMAJOR.0.0`): breaking changes to inputs, outputs, or behavior
+
+Until v1.0.0, minor-version bumps may include behaviour changes; pin to the full
+`vMAJOR.MINOR.PATCH` tag for the most stable experience.
+
+## State machine boundaries
+
+See [state-machines.md](state-machines.md) for the detailed state machine definitions
+for consumer pull requests, draft release preparation, bundled binary update, and
+workflow concurrency.


### PR DESCRIPTION
## Summary

This repository has automated release workflows (`prepare-draft-release`,
`prepare-release-update`) and a tag history but no documentation on who is
responsible for publishing releases, when bundle update PRs should be merged,
or which ref consumers should pin. This PR adds that documentation.

- **`CONTRIBUTING.md`**: issue reporting steps (security advisory path
  included), PR submission guide, commit message prefix convention, pointer to
  release reference policy
- **`docs/RELEASE.md`**: release lifecycle diagram, publish decision
  responsibility (human step, no auto-publish), bundled binary update cadence
  guideline (two-week target), `@main` vs tag reference policy table,
  semantic versioning intent, link to existing `state-machines.md`

## Changes

- `CONTRIBUTING.md`: new file
- `docs/RELEASE.md`: new file

## Verification

- No code changes; documentation only
- Cross-links to `docs/RELEASE.md` from `CONTRIBUTING.md` and back to
  `state-machines.md` from `RELEASE.md` are valid (both files exist)
- Collateral check: clean
- No Japanese characters in any added content (English public repo)
