### PR TITLE
docs: add publish responsibility to state-machines.md

### DIFF
--- a/docs/state-machines.md
+++ b/docs/state-machines.md
@@ -55,6 +55,19 @@ Boundary:
 - A published release is immutable for this workflow. To change a published
   release, publish a newer version instead of reusing the same tag.
 
+Responsibility:
+
+- A maintainer reviews the auto-generated draft release notes and clicks
+  **Publish release** in the GitHub Releases UI when the notes are accurate
+  and the release is ready.
+- No workflow publishes a release automatically; the publish step is always a
+  human decision.
+- If a draft accumulates without being published, a maintainer should either
+  publish it, delete it, or update `action.yml` to reflect the intended next
+  version.
+
+See [RELEASE.md](RELEASE.md) for release cadence guidance.
+
 Recovery:
 
 - If the workflow stops on `published-release`, rerun it with a new


### PR DESCRIPTION
## Summary

`docs/state-machines.md` defines the draft release state machine — states,
boundaries, and recovery steps — but does not say who is responsible for
advancing a draft to published. This omission leaves it implicit that a human
must act, and gives no guidance on when or under what conditions.

This PR adds a `Responsibility` section to the "Draft release preparation"
section clarifying:

- A maintainer reviews auto-generated release notes and publishes the draft
  manually via the GitHub Releases UI
- No workflow publishes a release automatically
- Guidance on what to do when a draft accumulates without being published
- A link to `docs/RELEASE.md` for cadence guidance

Note: `docs/RELEASE.md` is being added in a separate open PR (#75). The link
in this change will resolve once that PR merges; if it merges before this one,
both docs are in sync.

## Changes

- `docs/state-machines.md`: new `Responsibility` subsection in "Draft release
  preparation" section

## Verification

- Documentation change only; no code modified
- Collateral check: clean
- No Japanese characters (English public repo)
