### PR TITLE
fix(timeout): avoid false timeout marker after normal exit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,18 +166,5 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: preserves command exit status
-        run: |
-          set +e
-          scripts/run-with-timeout.sh 5 bash -c 'exit 7'
-          status=$?
-          set -e
-          [ "${status}" -eq 7 ]
-
-      - name: exits 124 when command exceeds timeout
-        run: |
-          set +e
-          scripts/run-with-timeout.sh 1 bash -c 'sleep 5'
-          status=$?
-          set -e
-          [ "${status}" -eq 124 ]
+      - name: runs timeout helper tests
+        run: scripts/test-run-with-timeout.sh

--- a/scripts/run-with-timeout.sh
+++ b/scripts/run-with-timeout.sh
@@ -32,14 +32,15 @@ command_pid=$!
 (
 	sleep "${timeout_seconds}"
 	if kill -0 "${command_pid}" 2>/dev/null; then
-		printf 'command timed out after %ss: %s\n' "${timeout_seconds}" "${command_display}" >&2
-		: >"${timeout_marker}"
 		# Signal the whole process group first; fall back to the direct PID.
-		kill -- -"${command_pid}" 2>/dev/null || kill "${command_pid}" 2>/dev/null || true
-		# SIGKILL fallback: give the process up to 5 s to exit gracefully.
-		sleep 5
-		if kill -0 "${command_pid}" 2>/dev/null; then
-			kill -9 -- -"${command_pid}" 2>/dev/null || kill -9 "${command_pid}" 2>/dev/null || true
+		if kill -- -"${command_pid}" 2>/dev/null || kill "${command_pid}" 2>/dev/null; then
+			printf 'command timed out after %ss: %s\n' "${timeout_seconds}" "${command_display}" >&2
+			: >"${timeout_marker}"
+			# SIGKILL fallback: give the process up to 5 s to exit gracefully.
+			sleep 5
+			if kill -0 "${command_pid}" 2>/dev/null; then
+				kill -9 -- -"${command_pid}" 2>/dev/null || kill -9 "${command_pid}" 2>/dev/null || true
+			fi
 		fi
 	fi
 ) &

--- a/scripts/test-run-with-timeout.sh
+++ b/scripts/test-run-with-timeout.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+run_with_timeout="${script_dir}/run-with-timeout.sh"
+
+test_preserves_command_exit_status() {
+	local status
+
+	set +e
+	"${run_with_timeout}" 5 bash -c 'exit 7'
+	status=$?
+	set -e
+
+	[ "${status}" -eq 7 ]
+}
+
+test_exits_124_when_command_exceeds_timeout() {
+	local status
+
+	set +e
+	"${run_with_timeout}" 1 bash -c 'sleep 5'
+	status=$?
+	set -e
+
+	[ "${status}" -eq 124 ]
+}
+
+test_preserves_normal_exit_during_timeout_race() {
+	local probe
+	local status
+
+	probe="$(mktemp)"
+	rm -f "${probe}"
+	trap 'rm -f "${probe}"' RETURN
+
+	# shellcheck disable=SC2329
+	kill() {
+		local result
+
+		if [ "${1:-}" = "-0" ] && [ -n "${RUN_WITH_TIMEOUT_RACE_PROBE:-}" ]; then
+			set +e
+			builtin kill "$@"
+			result=$?
+			set -e
+			if [ "${result}" -eq 0 ]; then
+				: >"${RUN_WITH_TIMEOUT_RACE_PROBE}"
+				sleep 0.2
+			fi
+			return "${result}"
+		fi
+
+		builtin kill "$@"
+	}
+	export -f kill
+	export RUN_WITH_TIMEOUT_RACE_PROBE="${probe}"
+
+	set +e
+	# shellcheck disable=SC2016
+	"${run_with_timeout}" 1 bash -c 'while [ ! -f "${RUN_WITH_TIMEOUT_RACE_PROBE}" ]; do sleep 0.01; done; exit 0'
+	status=$?
+	set -e
+
+	unset -f kill
+	unset RUN_WITH_TIMEOUT_RACE_PROBE
+
+	[ "${status}" -eq 0 ]
+}
+
+test_preserves_command_exit_status
+test_exits_124_when_command_exceeds_timeout
+test_preserves_normal_exit_during_timeout_race


### PR DESCRIPTION
## Summary
- write the timeout marker only after the watchdog successfully sends a timeout signal
- move timeout helper coverage into `scripts/test-run-with-timeout.sh`
- cover the normal-exit race that can happen after the watchdog's `kill -0` probe

## Motivation
The watchdog previously wrote the timeout marker after a successful liveness probe but before confirming that it could signal the wrapped command. If the command exited normally in that window, the wrapper could still return 124 even though no timeout was delivered.

## Verification
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `shellcheck scripts/*.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `typos`
- `git diff --check`
- `bash -n scripts/*.sh`
- `scripts/test-run-with-timeout.sh`
