### PR TITLE
fix(timeout): stop command group on parent signal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,3 +181,6 @@ jobs:
           status=$?
           set -e
           [ "${status}" -eq 124 ]
+
+      - name: stops command group when wrapper receives SIGTERM
+        run: bash scripts/test-run-with-timeout-signals.sh

--- a/scripts/run-with-timeout.sh
+++ b/scripts/run-with-timeout.sh
@@ -29,22 +29,43 @@ else
 fi
 command_pid=$!
 
+signal_command() {
+	local signal="$1"
+	kill "-${signal}" -- -"${command_pid}" 2>/dev/null || kill "-${signal}" "${command_pid}" 2>/dev/null || true
+}
+
+terminate_command() {
+	local signal="${1:-TERM}"
+	signal_command "${signal}"
+	sleep 5
+	if kill -0 "${command_pid}" 2>/dev/null; then
+		signal_command KILL
+	fi
+}
+
+# shellcheck disable=SC2329 # Invoked by signal traps.
+handle_parent_signal() {
+	local signal="$1"
+	local status="$2"
+	trap '' TERM INT
+	kill "${watchdog_pid}" 2>/dev/null || true
+	wait "${watchdog_pid}" 2>/dev/null || true
+	terminate_command "${signal}"
+	wait "${command_pid}" 2>/dev/null || true
+	exit "${status}"
+}
+
 (
 	sleep "${timeout_seconds}"
 	if kill -0 "${command_pid}" 2>/dev/null; then
 		printf 'command timed out after %ss: %s\n' "${timeout_seconds}" "${command_display}" >&2
 		: >"${timeout_marker}"
-		# Signal the whole process group first; fall back to the direct PID.
-		kill -- -"${command_pid}" 2>/dev/null || kill "${command_pid}" 2>/dev/null || true
-		# SIGKILL fallback: give the process up to 5 s to exit gracefully.
-		sleep 5
-		if kill -0 "${command_pid}" 2>/dev/null; then
-			kill -9 -- -"${command_pid}" 2>/dev/null || kill -9 "${command_pid}" 2>/dev/null || true
-		fi
+		terminate_command TERM
 	fi
 ) &
 watchdog_pid=$!
-trap 'kill "${watchdog_pid}" 2>/dev/null || true; wait "${watchdog_pid}" 2>/dev/null || true' TERM INT
+trap 'handle_parent_signal TERM 143' TERM
+trap 'handle_parent_signal INT 130' INT
 
 set +e
 wait "${command_pid}" 2>/dev/null

--- a/scripts/test-run-with-timeout-signals.sh
+++ b/scripts/test-run-with-timeout-signals.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v setsid >/dev/null 2>&1; then
+	echo "setsid unavailable; skipping process-group cancellation test"
+	exit 0
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "${tmpdir}"' EXIT
+marker="${tmpdir}/writes"
+: >"${marker}"
+
+scripts/run-with-timeout.sh 30 bash -c "trap '' TERM; (trap '' TERM; while true; do printf x >> \"\$1\"; sleep 0.2; done) & wait" _ "${marker}" &
+wrapper_pid=$!
+
+for _ in 1 2 3 4 5; do
+	if [ -s "${marker}" ]; then
+		break
+	fi
+	sleep 0.2
+done
+[ -s "${marker}" ]
+
+kill -TERM "${wrapper_pid}"
+set +e
+wait "${wrapper_pid}"
+status=$?
+set -e
+[ "${status}" -eq 143 ]
+
+bytes_after_wait="$(wc -c <"${marker}" | tr -d ' ')"
+sleep 1
+bytes_after_sleep="$(wc -c <"${marker}" | tr -d ' ')"
+[ "${bytes_after_wait}" = "${bytes_after_sleep}" ]


### PR DESCRIPTION
## Summary
- Propagate parent SIGTERM/SIGINT from the timeout wrapper to the wrapped command or process group while still stopping the watchdog.
- Preserve timeout behavior and exit status propagation.
- Add a signal regression test and run it from the timeout helper workflow job.

## Verification
- `implement-validator` foreground gate: passed
- `bash -n scripts/*.sh`
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `shellcheck scripts/*.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `typos`
- `git diff --check`
- `timeout helper smoke`: exit 7 propagation and timeout exit 124 passed
- `bash scripts/test-run-with-timeout-signals.sh`: skipped locally because `setsid` is unavailable in this environment; intended to run on Ubuntu CI where `setsid` exists
