### PR TITLE
ci: check required status contexts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,21 @@ permissions:
   issues: write
 
 jobs:
+  required-status-checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      checks: read
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: required status checks are produced
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: scripts/check-required-status-checks.sh --repo "${GITHUB_REPOSITORY}" --pr "${PR_NUMBER}"
+
   shell-format:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/scripts/check-required-status-checks.sh
+++ b/scripts/check-required-status-checks.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+# Verify that the default branch ruleset only requires checks produced by a PR.
+
+set -eu
+
+REPO="${GITHUB_REPOSITORY:-gitignore-in/gh-action}"
+RULESET_NAME="default-branch-baseline"
+PR_NUMBER="${PR_NUMBER:-}"
+
+usage() {
+	echo "Usage: $0 [--repo owner/repo] [--ruleset-name name] [--pr number]" >&2
+}
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+	--repo)
+		if [ "$#" -lt 2 ]; then
+			usage
+			exit 2
+		fi
+		REPO="$2"
+		shift 2
+		;;
+	--ruleset-name)
+		if [ "$#" -lt 2 ]; then
+			usage
+			exit 2
+		fi
+		RULESET_NAME="$2"
+		shift 2
+		;;
+	--pr)
+		if [ "$#" -lt 2 ]; then
+			usage
+			exit 2
+		fi
+		PR_NUMBER="$2"
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "Error: unknown argument: $1" >&2
+		usage
+		exit 2
+		;;
+	esac
+done
+
+if [ -z "${PR_NUMBER}" ] && [ -n "${GITHUB_EVENT_PATH:-}" ] && [ -f "${GITHUB_EVENT_PATH}" ]; then
+	PR_NUMBER=$(jq -r '.pull_request.number // empty' "${GITHUB_EVENT_PATH}")
+fi
+
+if [ -z "${PR_NUMBER}" ]; then
+	echo "Error: pull request number is required" >&2
+	usage
+	exit 2
+fi
+
+ruleset_ids=$(gh api "repos/${REPO}/rulesets" \
+	--jq ".[] | select(.name == \"${RULESET_NAME}\") | .id")
+
+if [ -z "${ruleset_ids}" ]; then
+	echo "Error: ruleset '${RULESET_NAME}' not found in ${REPO}" >&2
+	exit 1
+fi
+
+ruleset_count=$(printf '%s\n' "${ruleset_ids}" | sed '/^$/d' | wc -l | tr -d ' ')
+if [ "${ruleset_count}" -ne 1 ]; then
+	echo "Error: ruleset '${RULESET_NAME}' matched ${ruleset_count} rulesets in ${REPO}" >&2
+	exit 1
+fi
+
+ruleset_id=$(printf '%s\n' "${ruleset_ids}" | sed -n '1p')
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "${tmpdir}"' EXIT
+
+required_checks_file="${tmpdir}/required-checks"
+pr_checks_file="${tmpdir}/pr-checks"
+
+gh api "repos/${REPO}/rulesets/${ruleset_id}" \
+	--jq '.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[].context' |
+	sort -u >"${required_checks_file}"
+
+if [ ! -s "${required_checks_file}" ]; then
+	echo "Error: ruleset '${RULESET_NAME}' has no required_status_checks entries" >&2
+	exit 1
+fi
+
+set +e
+gh pr checks "${PR_NUMBER}" --repo "${REPO}" --json name --jq '.[].name' >"${pr_checks_file}"
+checks_status=$?
+set -e
+
+if [ "${checks_status}" -ne 0 ] && [ "${checks_status}" -ne 8 ]; then
+	echo "Error: failed to list checks for ${REPO}#${PR_NUMBER}" >&2
+	exit "${checks_status}"
+fi
+
+sort -u "${pr_checks_file}" -o "${pr_checks_file}"
+
+missing=0
+while IFS= read -r required_check; do
+	if ! grep -Fx -- "${required_check}" "${pr_checks_file}" >/dev/null; then
+		echo "Missing required status check context: ${required_check}" >&2
+		missing=1
+	fi
+done <"${required_checks_file}"
+
+if [ "${missing}" -ne 0 ]; then
+	echo "Ruleset '${RULESET_NAME}' requires checks that this PR does not produce." >&2
+	echo "Update the ruleset or restore the workflow job names before merging." >&2
+	exit 1
+fi
+
+echo "All required status check contexts are produced by ${REPO}#${PR_NUMBER}."


### PR DESCRIPTION
Summary:
- Add a pull request guard that reads the default branch ruleset and verifies every required status check context is produced by the current PR.
- Run the guard from the pull request workflow so stale required check names fail with an actionable message.

Tests:
- git diff --check
- sh -n scripts/*.sh
- go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh
- shellcheck scripts/*.sh
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color
- typos
- scripts/check-required-status-checks.sh --repo gitignore-in/gh-action --pr 78
