### PR TITLE
Reject duplicate ruleset names in configure script

### DIFF
--- a/scripts/configure-branch-ruleset.sh
+++ b/scripts/configure-branch-ruleset.sh
@@ -21,13 +21,23 @@ if [ "${1:-}" = "--dry-run" ]; then
 	DRY_RUN=true
 fi
 
-ruleset_id=$(gh api "repos/${REPO}/rulesets" |
+ruleset_ids=$(gh api "repos/${REPO}/rulesets" |
 	jq -r --arg name "${RULESET_NAME}" '.[] | select(.name == $name) | .id')
 
-if [ -z "${ruleset_id}" ]; then
+ruleset_count=$(printf '%s\n' "${ruleset_ids}" | sed '/^$/d' | wc -l | tr -d ' ')
+
+if [ "${ruleset_count}" -eq 0 ]; then
 	echo "Error: ruleset '${RULESET_NAME}' not found" >&2
 	exit 1
 fi
+
+if [ "${ruleset_count}" -ne 1 ]; then
+	echo "Error: expected exactly one ruleset named '${RULESET_NAME}', found ${ruleset_count}" >&2
+	printf 'Matching ruleset IDs:\n%s\n' "${ruleset_ids}" >&2
+	exit 1
+fi
+
+ruleset_id=$(printf '%s\n' "${ruleset_ids}" | sed -n '1p')
 
 required_checks='[
   {"context":"shell-format"},

--- a/scripts/test-configure-branch-ruleset.sh
+++ b/scripts/test-configure-branch-ruleset.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Test ruleset lookup edge cases without calling the GitHub API.
+
+set -eu
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "${tmpdir}"' EXIT
+
+cat >"${tmpdir}/gh" <<'SCRIPT'
+#!/bin/sh
+case "${GH_MOCK_RULESETS:-single}" in
+single)
+	printf '%s\n' 123
+	;;
+none)
+	:
+	;;
+duplicate)
+	printf '%s\n' 123 456
+	;;
+*)
+	echo "unexpected GH_MOCK_RULESETS=${GH_MOCK_RULESETS}" >&2
+	exit 2
+	;;
+esac
+SCRIPT
+chmod +x "${tmpdir}/gh"
+
+output=$(PATH="${tmpdir}:${PATH}" GH_MOCK_RULESETS=single scripts/configure-branch-ruleset.sh --dry-run)
+printf '%s\n' "${output}" | grep 'Dry run: would add required_status_checks to ruleset 123'
+
+set +e
+output=$(PATH="${tmpdir}:${PATH}" GH_MOCK_RULESETS=none scripts/configure-branch-ruleset.sh --dry-run 2>&1)
+status=$?
+set -e
+[ "${status}" -eq 1 ]
+printf '%s\n' "${output}" | grep "Error: ruleset 'default-branch-baseline' not found"
+
+set +e
+output=$(PATH="${tmpdir}:${PATH}" GH_MOCK_RULESETS=duplicate scripts/configure-branch-ruleset.sh --dry-run 2>&1)
+status=$?
+set -e
+[ "${status}" -eq 1 ]
+printf '%s\n' "${output}" | grep "Error: expected exactly one ruleset named 'default-branch-baseline', found 2"
+printf '%s\n' "${output}" | grep '123'
+printf '%s\n' "${output}" | grep '456'

--- a/scripts/test-configure-branch-ruleset.sh
+++ b/scripts/test-configure-branch-ruleset.sh
@@ -8,26 +8,45 @@ trap 'rm -rf "${tmpdir}"' EXIT
 
 cat >"${tmpdir}/gh" <<'SCRIPT'
 #!/bin/sh
-case "${GH_MOCK_RULESETS:-single}" in
-single)
-	printf '%s\n' 123
+# Find the API path (first repos/... argument after `api`).
+path=""
+for arg in "$@"; do
+	case "${arg}" in
+	repos/*)
+		if [ -z "${path}" ]; then path="${arg}"; fi
+		;;
+	esac
+done
+case "${path}" in
+*/rulesets)
+	# Ruleset list: returned as a JSON array, matching the GitHub API shape.
+	case "${GH_MOCK_RULESETS:-single}" in
+	single)
+		printf '%s\n' '[{"name":"default-branch-baseline","id":123}]'
+		;;
+	none)
+		printf '%s\n' '[]'
+		;;
+	duplicate)
+		printf '%s\n' '[{"name":"default-branch-baseline","id":123},{"name":"default-branch-baseline","id":456}]'
+		;;
+	*)
+		echo "unexpected GH_MOCK_RULESETS=${GH_MOCK_RULESETS}" >&2
+		exit 2
+		;;
+	esac
 	;;
-none)
-	:
-	;;
-duplicate)
-	printf '%s\n' 123 456
-	;;
-*)
-	echo "unexpected GH_MOCK_RULESETS=${GH_MOCK_RULESETS}" >&2
-	exit 2
+*/rulesets/*)
+	# Ruleset detail: existing required_status_checks differs from desired,
+	# so the script reports that an update is needed.
+	printf '%s\n' '{"rules":[{"type":"required_status_checks","parameters":{"required_status_checks":[]}}]}'
 	;;
 esac
 SCRIPT
 chmod +x "${tmpdir}/gh"
 
 output=$(PATH="${tmpdir}:${PATH}" GH_MOCK_RULESETS=single scripts/configure-branch-ruleset.sh --dry-run)
-printf '%s\n' "${output}" | grep 'Dry run: would add required_status_checks to ruleset 123'
+printf '%s\n' "${output}" | grep 'Dry run: would update required_status_checks in ruleset 123'
 
 set +e
 output=$(PATH="${tmpdir}:${PATH}" GH_MOCK_RULESETS=none scripts/configure-branch-ruleset.sh --dry-run 2>&1)


### PR DESCRIPTION
Summary:
- Validate that exactly one ruleset matches the configured ruleset name before using its ID.
- Report duplicate matching ruleset IDs with a clear error instead of passing a multiline ID into later API paths.
- Add a shell test that covers single, missing, and duplicate ruleset lookup results with a mocked gh CLI.

Tests:
- git diff --check
- sh -n scripts/*.sh
- go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh
- shellcheck scripts/*.sh
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color
- scripts/test-configure-branch-ruleset.sh
- typos
- scripts/configure-branch-ruleset.sh --dry-run
