### PR TITLE
Fix idempotency guard to compare rule content, not just presence

### DIFF
--- a/scripts/configure-branch-ruleset.sh
+++ b/scripts/configure-branch-ruleset.sh
@@ -40,17 +40,18 @@ required_checks='[
   {"context":"timeout helper"}
 ]'
 
-if "${DRY_RUN}"; then
-	echo "Dry run: would add required_status_checks to ruleset ${ruleset_id}"
-	echo "${required_checks}"
+current_sorted=$(gh api "repos/${REPO}/rulesets/${ruleset_id}" |
+	jq -r '[.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[].context] | sort | @json')
+desired_sorted=$(printf '%s' "${required_checks}" | jq -r '[.[].context] | sort | @json')
+
+if [ "${current_sorted}" = "${desired_sorted}" ]; then
+	echo "required_status_checks already up-to-date in ruleset ${ruleset_id}"
 	exit 0
 fi
 
-current=$(gh api "repos/${REPO}/rulesets/${ruleset_id}" \
-	--jq '[.rules[] | select(.type == "required_status_checks")]')
-
-if [ "${current}" != "[]" ]; then
-	echo "required_status_checks already present in ruleset ${ruleset_id}"
+if "${DRY_RUN}"; then
+	echo "Dry run: would update required_status_checks in ruleset ${ruleset_id}"
+	echo "${required_checks}"
 	exit 0
 fi
 
@@ -59,7 +60,7 @@ trap 'rm -f "${tmpfile}"' EXIT
 
 gh api "repos/${REPO}/rulesets/${ruleset_id}" \
 	--jq '{
-    rules: (.rules + [{
+    rules: ([.rules[] | select(.type != "required_status_checks")] + [{
       type: "required_status_checks",
       parameters: {
         strict_required_status_checks_policy: false,
@@ -71,4 +72,4 @@ gh api "repos/${REPO}/rulesets/${ruleset_id}" \
 gh api -X PUT "repos/${REPO}/rulesets/${ruleset_id}" \
 	--input "${tmpfile}" >/dev/null
 
-echo "Added required_status_checks to ruleset ${ruleset_id} (${RULESET_NAME})"
+echo "Updated required_status_checks in ruleset ${ruleset_id} (${RULESET_NAME})"


### PR DESCRIPTION
## Summary

The idempotency guard in `scripts/configure-branch-ruleset.sh` previously
only checked whether a `required_status_checks` rule *existed* in the ruleset,
not whether its content matched the desired state. If the rule was present but
stale (e.g. after a workflow job rename), the script would exit 0 with "already
present" and silently skip the update.

## Changes

- **Content-aware guard**: fetches the current required check contexts, sorts
  them, and compares against the desired set. Only skips if they match exactly.
- **Replace on update**: the PUT now removes any existing `required_status_checks`
  rule before adding the new one, so stale rules can't accumulate as duplicates.
- **Dry-run ordering**: the `--dry-run` early-exit now follows the content
  comparison, so dry-run also skips accurately when the ruleset is up-to-date.

## Verification

- `shfmt -d scripts/*.sh` — no diff
- `shellcheck scripts/*.sh` — no findings
- `actionlint` — no findings

## Trade-offs

The guard now makes an extra `gh api` GET call even when the rule is up-to-date.
This is a read-only call and adds negligible latency. In return, re-running the
script after any job rename correctly updates the ruleset instead of silently
doing nothing.
