### PR TITLE
fix: remove event_name from concurrency group to prevent parallel runs

### DIFF
--- a/.github/workflows/prepare-draft-release.yml
+++ b/.github/workflows/prepare-draft-release.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/prepare-release-update.yml
+++ b/.github/workflows/prepare-release-update.yml
@@ -19,7 +19,7 @@ on:
           - dry-run
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## What changed

Removed `${{ github.event_name }}-` from the `concurrency.group` key in two workflow files:

- `.github/workflows/prepare-draft-release.yml`
- `.github/workflows/prepare-release-update.yml`

**Before:**
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

**After:**
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

## Why

Including `github.event_name` in the concurrency group key caused runs triggered by different event types (e.g., `push`, `workflow_dispatch`, `repository_dispatch`) to be placed in **separate concurrency groups**, even when they were acting on the same ref.

This meant `cancel-in-progress: true` had no effect across trigger types: a `push`-triggered run and a `workflow_dispatch`-triggered run on the same branch would proceed in parallel, both writing to the same branch or release simultaneously and potentially causing conflicts or inconsistent state.

Removing `${{ github.event_name }}-` ensures all runs targeting the same ref are placed in the same concurrency group, so `cancel-in-progress: true` works as intended regardless of how the workflow was triggered.

## Verification

- actionlint passes
- shellcheck passes
- Collateral check clean (no other workflows affected)
