### PR TITLE
chore: restore Renovate custom manager for gitignore-in/gitignore-in version tracking

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,6 +25,17 @@
       ],
       "datasourceTemplate": "go",
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^action\\.yml$/"
+      ],
+      "matchStrings": [
+        "version=(?<currentValue>v\\d+\\.\\d+\\.\\d+)\\n"
+      ],
+      "depNameTemplate": "gitignore-in/gitignore-in",
+      "datasourceTemplate": "github-releases"
     }
   ]
 }


### PR DESCRIPTION
## What

Restored the Renovate regex custom manager in `.github/renovate.json5` that targets `action.yml`.

The restored entry matches the `version=` line in `action.yml` (e.g., line 94: `version=v0.2.1`) and tracks it against `github-releases` for the `gitignore-in/gitignore-in` dependency.

## Why

The previous removal of this custom manager left `repository_dispatch` as the only automated path for detecting new `gitignore-in/gitignore-in` releases. If the dispatch fails — due to upstream wiring gaps, event loss, or webhook misconfiguration — there is no automated fallback to detect version drift.

Renovate's regex manager now provides that fallback: it independently reads `action.yml` and opens a version bump PR whenever a new release is published, regardless of whether the dispatch event fires.

## Historical context

The bundled binary version in `action.yml` drifted for approximately 1.5 years in a prior incident, going undetected because no automated check was watching the value directly in the file. This shows the risk is real: a silent wiring gap can accumulate significant version lag before anyone notices. Having Renovate scan the file directly prevents that class of incident.

## Verification

- Only `.github/renovate.json5` is modified; no workflow files changed.
- `actionlint` collateral check passes (no `.github/workflows/` changes introduced).
- The regex pattern `version=(?<currentValue>v\d+\.\d+\.\d+)\n` matches the existing line format in `action.yml`.

## Notes

This PR is for human review. Do not enable auto-merge.
