### PR TITLE
fix: use jq --arg to pass RULESET_NAME instead of inline shell expansion

### DIFF
--- a/scripts/configure-branch-ruleset.sh
+++ b/scripts/configure-branch-ruleset.sh
@@ -21,8 +21,8 @@ if [ "${1:-}" = "--dry-run" ]; then
 	DRY_RUN=true
 fi
 
-ruleset_id=$(gh api "repos/${REPO}/rulesets" \
-	--jq ".[] | select(.name == \"${RULESET_NAME}\") | .id")
+ruleset_id=$(gh api "repos/${REPO}/rulesets" |
+	jq -r --arg name "${RULESET_NAME}" '.[] | select(.name == $name) | .id')
 
 if [ -z "${ruleset_id}" ]; then
 	echo "Error: ruleset '${RULESET_NAME}' not found" >&2


### PR DESCRIPTION
`scripts/configure-branch-ruleset.sh` used shell expansion to embed `${RULESET_NAME}`
directly into a double-quoted jq filter string:

```sh
# before
ruleset_id=$(gh api "repos/${REPO}/rulesets" \
    --jq ".[] | select(.name == \"${RULESET_NAME}\") | .id")
```

If `RULESET_NAME` contained `"` or `\`, the jq filter would break. While the current
value `"default-branch-baseline"` is safe, the code had no structural boundary between
the shell variable and the jq filter expression — the same pattern that enables
jq-injection if the variable becomes dynamic.

This change pipes the API response to `jq` with `--arg`, which passes the ruleset name
as a typed jq variable rather than splicing it into the filter source:

```sh
# after
ruleset_id=$(gh api "repos/${REPO}/rulesets" |
    jq -r --arg name "${RULESET_NAME}" '.[] | select(.name == $name) | .id')
```

## Verification

- `shfmt -d`: clean
- `shellcheck`: clean
