### PR TITLE
docs(check-required-status-checks): document implicit PR number input channels in usage()

### DIFF
--- a/scripts/check-required-status-checks.sh
+++ b/scripts/check-required-status-checks.sh
@@ -9,6 +9,11 @@ PR_NUMBER="${PR_NUMBER:-}"
 
 usage() {
 	echo "Usage: $0 [--repo owner/repo] [--ruleset-name name] [--pr number]"
+	echo ""
+	echo "The PR number is resolved in this order:"
+	echo "  1. --pr <number> (overrides PR_NUMBER)"
+	echo "  2. PR_NUMBER environment variable"
+	echo "  3. GITHUB_EVENT_PATH file (pull_request.number via jq; set in GitHub Actions)"
 }
 
 while [ "$#" -gt 0 ]; do


### PR DESCRIPTION
## Summary

`check-required-status-checks.sh` accepts the PR number through three different channels, but only `--pr` was documented in `usage()`. This meant that users running the script locally could not tell why the same invocation with no `--pr` flag worked in CI but failed locally.

## Changes

Expand `usage()` to show all three resolution steps in priority order:

1. `--pr <number>` flag (overrides `PR_NUMBER`)
2. `PR_NUMBER` environment variable
3. `GITHUB_EVENT_PATH` file (populated by GitHub Actions; provides `pull_request.number` via jq)

## Motivation

When `--pr` is omitted and `PR_NUMBER` is unset, the script falls back to reading `GITHUB_EVENT_PATH`, which is only available inside a GitHub Actions runner. Without this documentation, the error message `Error: pull request number is required` gives no hint about the fallback mechanism, making local debugging harder than necessary.

## Testing

Existing behavior is unchanged; this is a documentation-only fix to `usage()`. Verified with `shellcheck` (no new warnings) and `shfmt -d` (no format drift).