### PR TITLE
fix(test-run-with-timeout-signals): use SCRIPT_DIR instead of cwd-relative path

### DIFF
--- a/scripts/test-run-with-timeout-signals.sh
+++ b/scripts/test-run-with-timeout-signals.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 if ! command -v setsid >/dev/null 2>&1; then
 	echo "setsid unavailable; skipping process-group cancellation test"
 	exit 0
@@ -11,7 +13,7 @@ trap 'rm -rf "${tmpdir}"' EXIT
 marker="${tmpdir}/writes"
 : >"${marker}"
 
-scripts/run-with-timeout.sh 30 bash -c "trap '' TERM; (trap '' TERM; while true; do printf x >> \"\$1\"; sleep 0.2; done) & wait" _ "${marker}" &
+"${SCRIPT_DIR}/run-with-timeout.sh" 30 bash -c "trap '' TERM; (trap '' TERM; while true; do printf x >> \"\$1\"; sleep 0.2; done) & wait" _ "${marker}" &
 wrapper_pid=$!
 
 for _ in 1 2 3 4 5; do


### PR DESCRIPTION
## Summary

`test-run-with-timeout-signals.sh` called `scripts/run-with-timeout.sh` as a
path relative to the working directory. When the script is invoked from any
directory other than the repo root the lookup fails with "No such file or
directory", masking the actual signal-propagation test result.

## Changes

- Add `SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"` after `set -euo pipefail`
- Replace the cwd-relative `scripts/run-with-timeout.sh` invocation with
  `"${SCRIPT_DIR}/run-with-timeout.sh"`

The test now finds `run-with-timeout.sh` regardless of the caller's working
directory, matching the robustness expected of a self-contained test script.

## Testing

No functional change to the test logic. Verified with `shellcheck` (clean) and
`shfmt -d` (no format drift). The CI `timeout-helper` job already runs from
repo root and continues to work; the fix additionally handles non-root `cwd`
scenarios.