### PR TITLE
docs(check-required-status-checks): explain why gh pr checks exit 8 is tolerated

### DIFF
--- a/scripts/check-required-status-checks.sh
+++ b/scripts/check-required-status-checks.sh
@@ -95,6 +95,9 @@ gh pr checks "${PR_NUMBER}" --repo "${REPO}" --json name --jq '.[].name' >"${pr_
 checks_status=$?
 set -e
 
+# gh pr checks exits with code 8 when the PR has no checks (empty list).
+# This is not an error condition here — a PR with no checks simply produces an
+# empty file, which is handled correctly by the diff below.
 if [ "${checks_status}" -ne 0 ] && [ "${checks_status}" -ne 8 ]; then
 	echo "Error: failed to list checks for ${REPO}#${PR_NUMBER}" >&2
 	exit "${checks_status}"


### PR DESCRIPTION
## Summary

`check-required-status-checks.sh` silently accepted exit code 8 from
`gh pr checks` without explaining why. A future reader could easily mistake
this for an oversight and remove the special case, which would break PRs that
have no checks attached yet.

## Changes

Add a three-line comment above the exit-code guard to document that:

- `gh pr checks` exits 8 when the PR has no checks (empty list), not on a
  hard error.
- Treating exit 8 as non-fatal is intentional: the resulting empty file is
  handled correctly by the `comm`/`grep` diff further down.

## Motivation

The `gh` CLI does not formally document its exit code contract in a
machine-readable way. Recording the semantics in the code reduces the risk of
future regressions caused by "dead code" cleanup and makes the guard
self-documenting for anyone reading the script.

## Testing

Comment-only change; no functional modification. `shellcheck` and `shfmt -d`
both report no issues.