### PR TITLE
Use repository default branch when base_branch is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Windows and other platforms are not supported. The action exits with an error if
 | Input | Description | Default |
 |---|---|---|
 | `branch_name` | Branch name for the pull request | `gitignore-in` |
-| `base_branch` | Base branch for the pull request | `main` |
+| `base_branch` | Base branch for the pull request | repository default branch |
 | `commit_message` | Commit message for the `.gitignore` update | `Update .gitignore by gitignore.in` |
 | `pr_title` | Pull request title | `Update .gitignore` |
 | `pr_body` | Pull request body | `Update .gitignore by gitignore.in` |

--- a/action.yml
+++ b/action.yml
@@ -16,9 +16,9 @@ inputs:
   base_branch:
     description: |
       Base branch name to create pull request.
-      Default: main
+      Leave empty to use the repository's default branch.
     required: false
-    default: main
+    default: ""
   commit_message:
     description: |
       Commit message for the .gitignore update.
@@ -80,7 +80,7 @@ runs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         fetch-depth: 0
-        ref: ${{ inputs.base_branch }}
+        ref: ${{ inputs.base_branch || github.event.repository.default_branch }}
         path: repository
 
     - uses: gitignore-in/install-gibo@9e7dba9e59f184b41f542669b0864687a6f69b45 # v0.1.0
@@ -152,7 +152,7 @@ runs:
       id: create_pull_request
       with:
         branch: ${{ inputs.branch_name }}
-        base: ${{ inputs.base_branch }}
+        base: ${{ inputs.base_branch || github.event.repository.default_branch }}
         path: repository
         commit-message: ${{ inputs.commit_message }}
         delete-branch: ${{ inputs.delete_branch }}


### PR DESCRIPTION
## Why

The `base_branch` input defaulted to the static string `"main"`, causing incorrect PR targets for repositories whose default branch is not `main` (e.g. `master`, `trunk`, `develop`). When the caller does not set `base_branch`, the action would silently open PRs against `main` even if that branch does not exist or is not the default.

## What changed

- Changed the `base_branch` default from `"main"` to `""`.
- Both the `actions/checkout` step and `peter-evans/create-pull-request` step now resolve the effective base branch via `${{ inputs.base_branch || github.event.repository.default_branch }}`, which expands to the calling repository's actual default branch at runtime.
- Updated the README Inputs table to document the new dynamic default.

## Verification

- `actionlint` passes with no findings.
- `shellcheck` / `shfmt` pass (no shell changes).
- Existing callers that set `base_branch` explicitly are unaffected; the fallback only applies when the input is empty.
