### PR TITLE
docs: add CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GitHub Action for gitignore-in
 
+[![CI](https://github.com/gitignore-in/gh-action/actions/workflows/main.yml/badge.svg)](https://github.com/gitignore-in/gh-action/actions/workflows/main.yml)
+
 gitignore-in is a tool to generate .gitignore files from templates.
 This action runs gitignore-in and commits the result to the repository.
 


### PR DESCRIPTION
Add a CI status badge for the `main.yml` workflow to the README.

The repository has an active CI workflow (`main.yml`) but the README showed no
build status indicator. Visitors checking the repo before adopting the action
had to navigate to the Actions tab manually to verify CI health.

## Changes

- `README.md`: add `[![CI](…)](…)` badge after the title heading

## Verification

- No workflow or script files changed; actionlint and shellcheck pass.
- `shfmt` had no changes to apply.
