### PR TITLE
fix: use bash and set -o pipefail in check-required-status-checks.sh

### DIFF
--- a/scripts/check-required-status-checks.sh
+++ b/scripts/check-required-status-checks.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Verify that the default branch ruleset only requires checks produced by a PR.
 
-set -eu
+set -euo pipefail
 
 REPO="${GITHUB_REPOSITORY:-gitignore-in/gh-action}"
 RULESET_NAME="default-branch-baseline"


### PR DESCRIPTION
Without `set -o pipefail`, a failure in `gh api` at the start of the pipeline

```sh
gh api "repos/${REPO}/rulesets/${ruleset_id}" \
    --jq '.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[].context' |
    sort -u >"${required_checks_file}"
```

is silently swallowed by `sort -u`, leaving `required_checks_file` empty. The script then exits with a misleading "ruleset has no required_status_checks entries" error instead of surfacing the real cause (auth failure, network error, rate limit, etc.).

POSIX `sh` does not support `set -o pipefail`, so switch the shebang to `bash` — consistent with `run-with-timeout.sh` and the other scripts in this repo that already use `#!/usr/bin/env bash` with `set -euo pipefail`.

**Changes:**
- `scripts/check-required-status-checks.sh`: `#!/bin/sh` → `#!/usr/bin/env bash`, `set -eu` → `set -euo pipefail`

**Verification:**
- `shfmt -d scripts/*.sh`: no diff
- `shellcheck scripts/*.sh`: no warnings
- `actionlint -color`: no warnings
