### PR TITLE
fix: use jq --arg to pass RULESET_NAME in check-required-status-checks.sh

### DIFF
--- a/scripts/check-required-status-checks.sh
+++ b/scripts/check-required-status-checks.sh
@@ -59,8 +59,8 @@ if [ -z "${PR_NUMBER}" ]; then
 	exit 2
 fi
 
-ruleset_ids=$(gh api "repos/${REPO}/rulesets" \
-	--jq ".[] | select(.name == \"${RULESET_NAME}\") | .id")
+ruleset_ids=$(gh api "repos/${REPO}/rulesets" |
+	jq -r --arg name "${RULESET_NAME}" '.[] | select(.name == $name) | .id')
 
 if [ -z "${ruleset_ids}" ]; then
 	echo "Error: ruleset '${RULESET_NAME}' not found in ${REPO}" >&2


### PR DESCRIPTION
## Problem

In `scripts/check-required-status-checks.sh`, `RULESET_NAME` was directly shell-expanded into a jq filter string:

```sh
gh api ... | jq -r ".[] | select(.name == \"${RULESET_NAME}\")"
```

If the ruleset name contains `"` or `\`, the jq filter would be syntactically broken or behave incorrectly (jq literal injection).

## Fix

Changed to pipe `gh api` output to `jq -r --arg name "${RULESET_NAME}"`, using jq's `--arg` option to safely separate data from code:

```sh
gh api ... | jq -r --arg name "${RULESET_NAME}" '.[] | select(.name == $name)'
```

This is the same pattern applied to `configure-branch-ruleset.sh` in PR #85.

## Verification

- shellcheck: pass
- shfmt: pass
- actionlint: pass

## Scope

Single-line change in `scripts/check-required-status-checks.sh`. Functionally equivalent for typical ruleset names; prevents corruption for names containing `"` or `\`.
