### PR TITLE
repo: add .github/settings.yml to track repository topics

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,7 @@
+# Repository settings managed by probot/settings.
+# https://github.com/probot/settings
+repository:
+  topics:
+    - github-actions
+    - gitignore
+    - pull-request


### PR DESCRIPTION
## Summary

Add `.github/settings.yml` to document the repository topics in version control.

Topics set: `github-actions`, `gitignore`, `pull-request`

## Why

The repository had no GitHub topics, reducing discoverability on GitHub Marketplace
and topic search. Users looking for GitHub Actions related to gitignore management
could not find this action through topic-based discovery.

The topics have been applied directly via the GitHub API. This file documents
the intended configuration so it can be maintained via probot/settings if
installed in the future.

## Changes

- `.github/settings.yml`: declares `github-actions`, `gitignore`, and `pull-request` as repository topics

## Trade-offs

- `.github/settings.yml` only takes effect with probot/settings installed; without it, this is documentation only.
- The topics themselves are already active — this PR tracks the intent in code.
