### PR TITLE
ci: scope prepare release workflow permissions

### DIFF
--- a/.github/workflows/prepare-release-update.yml
+++ b/.github/workflows/prepare-release-update.yml
@@ -22,14 +22,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   resolve:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.resolve.outputs.version }}
       mode: ${{ steps.resolve.outputs.mode }}
@@ -69,6 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: resolve
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -108,6 +108,9 @@ jobs:
     timeout-minutes: 10
     needs: [resolve, validate]
     if: ${{ needs.resolve.outputs.mode != 'dry-run' }}
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 


### PR DESCRIPTION
## Summary
- Remove workflow-level write permissions from the release update preparation workflow.
- Give the read-only resolve and validate jobs `contents: read` only.
- Keep `contents: write` and `pull-requests: write` scoped to the job that opens the update pull request.

## Verification
- `git diff --check`
- `actionlint`
- `shfmt -d scripts/*.sh`
- `shellcheck scripts/*.sh`
- `typos`
- workflow permissions YAML assertion
- collateral check: clean
