### PR TITLE
ci: check that action.yml version and bundled-binary.sha256 are coherent

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,16 @@ jobs:
         with:
           scandir: ./scripts
 
+  version-coherence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: action.yml and bundled-binary.sha256 are coherent
+        run: scripts/check-version-sha256-coherence.sh
+
   diff-detection:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/scripts/check-version-sha256-coherence.sh
+++ b/scripts/check-version-sha256-coherence.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify that the version referenced in action.yml matches every entry in
+# bundled-binary.sha256. When a Renovate PR updates only the version= line in
+# action.yml without regenerating bundled-binary.sha256, the download step fails
+# at workflow runtime because grep finds no matching checksum line.
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+
+action_file="${repo_root}/action.yml"
+sha256_file="${repo_root}/bundled-binary.sha256"
+
+action_version="$(grep -E '^\s+version=v[0-9]+\.[0-9]+\.[0-9]+$' "${action_file}" | sed -E 's/.*version=(v[0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+if [ -z "${action_version}" ]; then
+	echo "ERROR: could not extract version= from ${action_file}" >&2
+	exit 1
+fi
+echo "action.yml version: ${action_version}"
+
+total="$(grep -c . "${sha256_file}" || true)"
+if [ "${total}" -eq 0 ]; then
+	echo "ERROR: ${sha256_file} is empty" >&2
+	exit 1
+fi
+
+matching="$(grep -cF "${action_version}" "${sha256_file}" || true)"
+echo "bundled-binary.sha256: ${matching}/${total} entries match ${action_version}"
+
+if [ "${matching}" -ne "${total}" ]; then
+	echo "ERROR: version mismatch — action.yml references ${action_version}" >&2
+	echo "       but ${total} entries exist and only ${matching} contain ${action_version}" >&2
+	echo "       Run scripts/update-version.sh ${action_version} to regenerate bundled-binary.sha256" >&2
+	exit 1
+fi
+
+echo "OK: all ${total} entries in bundled-binary.sha256 are coherent with ${action_version}"


### PR DESCRIPTION
## Summary

- Add `scripts/check-version-sha256-coherence.sh` to verify the `version=` line in `action.yml` matches all four platform entries in `bundled-binary.sha256`
- Add a `version-coherence` CI job that runs this check on every pull request

## Problem

The Renovate custom manager in `.github/renovate.json5` tracks `gitignore-in/gitignore-in` releases and updates the `version=vX.Y.Z` line in `action.yml` via regex. It does not update `bundled-binary.sha256`.

When such a Renovate PR merges, `action.yml` references the new version but `bundled-binary.sha256` still contains checksums for the previous version. At workflow runtime, the download step runs:

```sh
grep -F "  ${target}" bundled-binary.sha256 > "${target}.sha256"
shasum -a 256 -c "${target}.sha256"
```

Because the new-version filename is not in `bundled-binary.sha256`, the grep produces an empty file and `shasum` fails with a verification error. Every consumer workflow breaks.

CI previously had no check for this coherence invariant, so Renovate PRs passed green.

## Changes

**`scripts/check-version-sha256-coherence.sh`** — reads `version=` from `action.yml`, counts how many lines in `bundled-binary.sha256` contain that version string, and exits non-zero if the counts do not match.

**`.github/workflows/main.yml`** — new `version-coherence` job runs the script on every PR. A Renovate PR that touches only `action.yml` will now fail this job, making the missing checksum update visible before merge.

## Verification

Runs cleanly on the current coherent state (v0.2.1):

```
action.yml version: v0.2.1
bundled-binary.sha256: 4/4 entries match v0.2.1
OK: all 4 entries in bundled-binary.sha256 are coherent with v0.2.1
```

Would fail if only `action.yml` were bumped to a hypothetical v0.3.0:

```
action.yml version: v0.3.0
bundled-binary.sha256: 0/4 entries match v0.3.0
ERROR: version mismatch — action.yml references v0.3.0
       but 4 entries exist and only 0 contain v0.3.0
       Run scripts/update-version.sh v0.3.0 to regenerate bundled-binary.sha256
```

## Trade-offs

The check reads local files only (no network) and runs in under a second. It does not prevent Renovate from opening the partial-update PR; it prevents the PR from merging unnoticed. The proper fix for a partial-update PR is to run `scripts/update-version.sh <new-version>`.
