### PR TITLE
Document repository_dispatch payload schema for prepare-release-update

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -34,6 +34,36 @@ When `gitignore-in/gitignore-in` publishes a new release, the `prepare action re
 workflow can be triggered automatically via `repository_dispatch` from upstream,
 or manually via workflow dispatch.
 
+### Upstream dispatch payload schema
+
+The workflow listens for `repository_dispatch` events of type `gitignore-in-release-published`.
+The `client_payload` must conform to the following schema:
+
+| Field | Type | Required | Valid values | Default |
+|---|---|---|---|---|
+| `version` | string | **required** | `vMAJOR.MINOR.PATCH` format (e.g. `v0.3.0`) | — |
+| `mode` | string | optional | `prepare-pr`, `dry-run` | `prepare-pr` |
+
+**`version`** must match the pattern `^v[0-9]+\.[0-9]+\.[0-9]+$`; the workflow exits with
+an error if the pattern does not match or the field is absent.
+
+**`mode`** controls workflow behaviour:
+- `prepare-pr` (default): validate the release and open an update pull request.
+- `dry-run`: validate the release only; skip pull request creation.
+
+If `mode` is omitted the workflow silently defaults to `prepare-pr`.
+Passing any value other than the two above causes the workflow to exit with an error.
+
+Example dispatch invocation via `gh`:
+
+```sh
+gh api repos/gitignore-in/gh-action/dispatches \
+  --method POST \
+  --field event_type=gitignore-in-release-published \
+  --field 'client_payload[version]=v0.3.0' \
+  --field 'client_payload[mode]=dry-run'
+```
+
 ### Human responsibility
 
 The `prepare action release update` workflow opens a pull request. A maintainer must:


### PR DESCRIPTION
## Summary

The `prepare-release-update.yml` workflow listens for `repository_dispatch`
events of type `gitignore-in-release-published` and reads two fields from
`client_payload` — `version` (required) and `mode` (optional, defaulting
to `prepare-pr`) — but neither field was documented anywhere in the repository.

This makes it hard for dispatch senders to know the expected schema, the
valid values for `mode`, or that an omitted `mode` silently defaults rather
than failing.

## Changes

`docs/RELEASE.md`: add an "Upstream dispatch payload schema" subsection under
"Bundled binary update" that describes:
- the dispatch event type (`gitignore-in-release-published`)
- the `client_payload` field table (name, type, required/optional, valid values, default)
- validation rules (version format, mode allowed values, silent default behaviour)
- a worked `gh` CLI invocation example

## Verification

The workflow validation logic itself is unchanged. The added documentation
reflects the existing behaviour in `.github/workflows/prepare-release-update.yml`.

Actionlint and shellcheck pass (no shell changes in this PR).
