### PR TITLE
Fix inaccurate intro description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GitHub Action for gitignore-in
 
 gitignore-in is a tool to generate .gitignore files from templates.
-This action runs gitignore-in and commits the result to the repository.
+This action runs gitignore-in and creates a pull request if the `.gitignore` file has changed.
 
 ## Example
 


### PR DESCRIPTION
The opening description said the action "commits the result to the repository", but it actually creates a pull request via `peter-evans/create-pull-request`. The same README (line 23) and `action.yml` description already state the correct behavior.

This fixes the inconsistency so users reading the intro are not misled into expecting a direct commit — which would fail under branch protection rules that require PRs.
