### PR TITLE
fix(timeout): avoid false timeout marker after normal exit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -190,21 +190,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: preserves command exit status
-        run: |
-          set +e
-          scripts/run-with-timeout.sh 5 bash -c 'exit 7'
-          status=$?
-          set -e
-          [ "${status}" -eq 7 ]
-
-      - name: exits 124 when command exceeds timeout
-        run: |
-          set +e
-          scripts/run-with-timeout.sh 1 bash -c 'sleep 5'
-          status=$?
-          set -e
-          [ "${status}" -eq 124 ]
+      - name: runs timeout helper tests
+        run: bash scripts/test-run-with-timeout.sh
 
       - name: stops command group when wrapper receives SIGTERM
         run: bash scripts/test-run-with-timeout-signals.sh

--- a/scripts/run-with-timeout.sh
+++ b/scripts/run-with-timeout.sh
@@ -31,16 +31,21 @@ command_pid=$!
 
 signal_command() {
 	local signal="$1"
-	kill "-${signal}" -- -"${command_pid}" 2>/dev/null || kill "-${signal}" "${command_pid}" 2>/dev/null || true
+	kill "-${signal}" -- -"${command_pid}" 2>/dev/null || kill "-${signal}" "${command_pid}" 2>/dev/null
 }
 
-terminate_command() {
-	local signal="${1:-TERM}"
-	signal_command "${signal}"
+kill_after_grace() {
 	sleep 5
 	if kill -0 "${command_pid}" 2>/dev/null; then
-		signal_command KILL
+		signal_command KILL || true
 	fi
+}
+
+# shellcheck disable=SC2329 # Invoked by signal traps through handle_parent_signal.
+terminate_command() {
+	local signal="${1:-TERM}"
+	signal_command "${signal}" || return 1
+	kill_after_grace
 }
 
 # shellcheck disable=SC2329 # Invoked by signal traps.
@@ -50,7 +55,7 @@ handle_parent_signal() {
 	trap '' TERM INT
 	kill "${watchdog_pid}" 2>/dev/null || true
 	wait "${watchdog_pid}" 2>/dev/null || true
-	terminate_command "${signal}"
+	terminate_command "${signal}" || true
 	wait "${command_pid}" 2>/dev/null || true
 	exit "${status}"
 }
@@ -58,9 +63,11 @@ handle_parent_signal() {
 (
 	sleep "${timeout_seconds}"
 	if kill -0 "${command_pid}" 2>/dev/null; then
-		printf 'command timed out after %ss: %s\n' "${timeout_seconds}" "${command_display}" >&2
-		: >"${timeout_marker}"
-		terminate_command TERM
+		if signal_command TERM; then
+			printf 'command timed out after %ss: %s\n' "${timeout_seconds}" "${command_display}" >&2
+			: >"${timeout_marker}"
+			kill_after_grace
+		fi
 	fi
 ) &
 watchdog_pid=$!

--- a/scripts/test-run-with-timeout.sh
+++ b/scripts/test-run-with-timeout.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+run_with_timeout="${RUN_WITH_TIMEOUT_BIN:-${script_dir}/run-with-timeout.sh}"
+
+test_preserves_command_exit_status() {
+	local status
+
+	set +e
+	"${run_with_timeout}" 5 bash -c 'exit 7'
+	status=$?
+	set -e
+
+	[ "${status}" -eq 7 ]
+}
+
+test_exits_124_when_command_exceeds_timeout() {
+	local status
+
+	set +e
+	"${run_with_timeout}" 1 bash -c 'sleep 5'
+	status=$?
+	set -e
+
+	[ "${status}" -eq 124 ]
+}
+
+test_preserves_normal_exit_during_timeout_race() {
+	local probe
+	local status
+
+	probe="$(mktemp)"
+	rm -f "${probe}"
+
+	# shellcheck disable=SC2329 # Invoked by the child bash running run-with-timeout.sh.
+	kill() {
+		local pid
+		local target
+
+		if [ "${1:-}" = "-TERM" ] && [ -n "${RUN_WITH_TIMEOUT_RACE_PROBE:-}" ]; then
+			for target in "$@"; do :; done
+			pid="${target#-}"
+			if [[ "${pid}" =~ ^[0-9]+$ ]]; then
+				: >"${RUN_WITH_TIMEOUT_RACE_PROBE}"
+				for _ in 1 2 3 4 5 6 7 8 9 10; do
+					if ! builtin kill -0 "${pid}" 2>/dev/null; then
+						break
+					fi
+					sleep 0.1
+				done
+			fi
+		fi
+
+		builtin kill "$@"
+	}
+	export -f kill
+	export RUN_WITH_TIMEOUT_RACE_PROBE="${probe}"
+
+	set +e
+	# shellcheck disable=SC2016 # The child command reads RUN_WITH_TIMEOUT_RACE_PROBE.
+	"${run_with_timeout}" 1 bash -c 'while [ ! -f "${RUN_WITH_TIMEOUT_RACE_PROBE}" ]; do sleep 0.01; done; exit 0'
+	status=$?
+	set -e
+
+	unset -f kill
+	unset RUN_WITH_TIMEOUT_RACE_PROBE
+	rm -f "${probe}"
+
+	[ "${status}" -eq 0 ]
+}
+
+test_preserves_command_exit_status
+test_exits_124_when_command_exceeds_timeout
+test_preserves_normal_exit_during_timeout_race


### PR DESCRIPTION
## Summary

- Create the timeout marker only after the watchdog successfully sends the timeout signal.
- Move timeout helper coverage into `scripts/test-run-with-timeout.sh`.
- Add a regression test for the normal-exit race between the watchdog liveness probe and timeout signal delivery.

## Changes

- Update `scripts/run-with-timeout.sh` so timeout classification depends on successful signal delivery.
- Replace the inline timeout-helper checks in `.github/workflows/main.yml` with the shared test script.
- Add `scripts/test-run-with-timeout.sh` for timeout exit, command exit, and race regression coverage.

## Motivation

The watchdog previously treated a successful liveness probe as enough evidence to mark the command as timed out. If the command exited normally before the timeout signal was delivered, the wrapper could still report exit 124. This change makes the timeout marker reflect successful signal delivery instead.

## Verification

- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `shellcheck scripts/*.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `typos`
- `git diff --check`
- `bash -n scripts/*.sh`
- `scripts/test-run-with-timeout.sh`
- `bash scripts/test-run-with-timeout-signals.sh`
- Regression check: `scripts/test-run-with-timeout.sh` fails against the previous `run-with-timeout.sh` and passes on this branch.
- Collateral check: clean

## Notes

- The process-group signal test skips on hosts without `setsid`; GitHub's Ubuntu runner provides `setsid`.
