### PR TITLE
feat: add gitignore-version input for binary version override

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Windows and other platforms are not supported. The action exits with an error if
 | `pr_body` | Pull request body | `Update .gitignore by gitignore.in` |
 | `delete_branch` | Delete the branch after merge | `true` |
 | `boilerplates_ref` | Git ref (branch, tag, or SHA) of the [toptal/gitignore](https://github.com/toptal/gitignore) boilerplates database to pin. When set, every run produces identical `.gitignore` output for the same `.gitignore.in` template. Leave empty to always use the latest boilerplates (default, non-deterministic). | `""` |
+| `gitignore-version` | Version of the `gitignore-in` binary to download (e.g. `v0.2.1`). When set to the bundled default, the binary is verified against `bundled-binary.sha256`. For any other version, SHA-256 verification is skipped; intended for testing pre-release binaries only. | `v0.2.1` |
+
+> **Note on input naming:** The existing inputs above (`branch_name`, `base_branch`, etc.) use
+> `snake_case` for historical reasons. The newer `gitignore-version` input uses `kebab-case` to
+> align with the outputs convention. A future major release will standardise all inputs to
+> `kebab-case`; until then, the table above shows the exact key names to use in `with:`.
 
 ### Pinning the boilerplates database
 

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,16 @@ inputs:
       behaviour, non-deterministic).
     required: false
     default: ""
+  gitignore-version:
+    description: |
+      Version of the gitignore-in binary to download (e.g. v0.2.1).
+      Defaults to the version bundled with this action release.
+      When set to the bundled version, the download is verified against
+      bundled-binary.sha256. When overridden to another version, SHA-256
+      verification is skipped and a warning is printed; use only for
+      testing pre-release binaries.
+    required: false
+    default: "v0.2.1"
 outputs:
   pull-request-number:
     description: Pull request number.
@@ -91,7 +101,8 @@ runs:
         tmpdir=$(mktemp -d)
         trap 'rm -rf "${tmpdir}"' EXIT
         cd "${tmpdir}"
-        version=v0.2.1
+        version="${GITIGNORE_IN_VERSION}"
+        bundled_version="v0.2.1"
         case "${RUNNER_OS}-${RUNNER_ARCH}" in
           Linux-X64)
             target="gitignore-in-x86_64-unknown-linux-gnu-${version}.tar.gz"
@@ -113,13 +124,19 @@ runs:
         url="https://github.com/gitignore-in/gitignore-in/releases/download/${version}/${target}"
         echo "Downloading ${url} (${RUNNER_OS}-${RUNNER_ARCH})" >&2
         wget --tries=3 --timeout=60 "${url}"
-        grep -F "  ${target}" "${GITHUB_ACTION_PATH}/bundled-binary.sha256" > "${target}.sha256"
-        shasum -a 256 -c "${target}.sha256"
+        if [ "${version}" = "${bundled_version}" ]; then
+          grep -F "  ${target}" "${GITHUB_ACTION_PATH}/bundled-binary.sha256" > "${target}.sha256"
+          shasum -a 256 -c "${target}.sha256"
+        else
+          echo "::warning::Custom gitignore-version '${version}' used; SHA-256 verification skipped. Only use for testing pre-release binaries." >&2
+        fi
         tar -xzf "${target}"
         mkdir -p "${RUNNER_TEMP}/gitignore-in/bin"
         install -m 0755 gitignore.in "${tmpdir}/gitignore.in.installed"
         mv "${tmpdir}/gitignore.in.installed" "${RUNNER_TEMP}/gitignore-in/bin/gitignore.in"
         echo "${RUNNER_TEMP}/gitignore-in/bin" >> "${GITHUB_PATH}"
+      env:
+        GITIGNORE_IN_VERSION: ${{ inputs.gitignore-version }}
       shell: bash
 
     - name: run gitignore.in


### PR DESCRIPTION
## Summary

Previously the `gitignore-in` binary version was hardcoded inside the shell
step with no way for callers to override it. Users who wanted to test a
different binary version had to fork the action or pin to a specific SHA.

This PR adds a `gitignore-version` input (default: `v0.2.1`) that allows
callers to specify which binary release to download. When the value matches
the bundled version, SHA-256 integrity is verified as before using
`bundled-binary.sha256`. For any other value a GitHub Actions warning is
emitted and verification is skipped (intentional trade-off for pre-release
testing).

## Changes

- `action.yml`: add `gitignore-version` input; pass version through an `env:`
  variable to avoid expression injection; add conditional SHA-256 check
- `README.md`: document the new input; add a naming-convention note explaining
  the current `snake_case` / `kebab-case` split between existing inputs and
  outputs, pointing to planned normalisation in a future major release

## Verification

- `actionlint`: no findings
- Collateral check: clean (no `gha-inline-script`, `version-shrink`, or
  `too-many-files` violations)
- No existing callers are affected; the default value preserves current behaviour
