### PR TITLE
fix: send --help output to stdout instead of stderr

### DIFF
--- a/scripts/check-required-status-checks.sh
+++ b/scripts/check-required-status-checks.sh
@@ -8,14 +8,14 @@ RULESET_NAME="default-branch-baseline"
 PR_NUMBER="${PR_NUMBER:-}"
 
 usage() {
-	echo "Usage: $0 [--repo owner/repo] [--ruleset-name name] [--pr number]" >&2
+	echo "Usage: $0 [--repo owner/repo] [--ruleset-name name] [--pr number]"
 }
 
 while [ "$#" -gt 0 ]; do
 	case "$1" in
 	--repo)
 		if [ "$#" -lt 2 ]; then
-			usage
+			usage >&2
 			exit 2
 		fi
 		REPO="$2"
@@ -23,7 +23,7 @@ while [ "$#" -gt 0 ]; do
 		;;
 	--ruleset-name)
 		if [ "$#" -lt 2 ]; then
-			usage
+			usage >&2
 			exit 2
 		fi
 		RULESET_NAME="$2"
@@ -31,7 +31,7 @@ while [ "$#" -gt 0 ]; do
 		;;
 	--pr)
 		if [ "$#" -lt 2 ]; then
-			usage
+			usage >&2
 			exit 2
 		fi
 		PR_NUMBER="$2"
@@ -43,7 +43,7 @@ while [ "$#" -gt 0 ]; do
 		;;
 	*)
 		echo "Error: unknown argument: $1" >&2
-		usage
+		usage >&2
 		exit 2
 		;;
 	esac


### PR DESCRIPTION
## Summary

`scripts/check-required-status-checks.sh` had `usage()` unconditionally writing to stderr (`>&2`). Per POSIX guidelines and GNU coding standards, `--help` output should go to stdout so users can redirect or pipe it.

**Before:**
```sh
# script --help > help.txt  → help.txt is empty (text went to stderr)
# script --help | less      → nothing piped (text went to stderr)
```

**After:**
```sh
# script --help > help.txt  → help.txt contains the usage text ✓
# script --help | less      → piped correctly ✓
```

## Changes

- `usage()` now writes to stdout (removed `>&2` from the function body)
- Error call sites (`--repo`/`--ruleset-name`/`--pr` missing argument, unknown flag) now call `usage >&2` explicitly to preserve stderr behavior

## Verification

- `shellcheck scripts/*.sh` — clean
- `shfmt -d scripts/*.sh` — no diff
- `actionlint` — clean
