### PR TITLE
fix: redirect diagnostic echo to stderr in configure-branch-ruleset.sh

### DIFF
--- a/scripts/configure-branch-ruleset.sh
+++ b/scripts/configure-branch-ruleset.sh
@@ -45,12 +45,12 @@ current_sorted=$(gh api "repos/${REPO}/rulesets/${ruleset_id}" |
 desired_sorted=$(printf '%s' "${required_checks}" | jq -r '[.[].context] | sort | @json')
 
 if [ "${current_sorted}" = "${desired_sorted}" ]; then
-	echo "required_status_checks already up-to-date in ruleset ${ruleset_id}"
+	echo "required_status_checks already up-to-date in ruleset ${ruleset_id}" >&2
 	exit 0
 fi
 
 if "${DRY_RUN}"; then
-	echo "Dry run: would update required_status_checks in ruleset ${ruleset_id}"
+	echo "Dry run: would update required_status_checks in ruleset ${ruleset_id}" >&2
 	echo "${required_checks}"
 	exit 0
 fi
@@ -72,4 +72,4 @@ gh api "repos/${REPO}/rulesets/${ruleset_id}" \
 gh api -X PUT "repos/${REPO}/rulesets/${ruleset_id}" \
 	--input "${tmpfile}" >/dev/null
 
-echo "Updated required_status_checks in ruleset ${ruleset_id} (${RULESET_NAME})"
+echo "Updated required_status_checks in ruleset ${ruleset_id} (${RULESET_NAME})" >&2


### PR DESCRIPTION
## Summary

In `--dry-run` mode, `configure-branch-ruleset.sh` sent both a diagnostic
message and the JSON payload to stdout. Piping the output to `jq` caused a
parse error because the diagnostic text appeared before the JSON:

```sh
./scripts/configure-branch-ruleset.sh --dry-run | jq .   # fails
```

## Changes

- `echo "Dry run: would update ..." >&2` — diagnostic to stderr; JSON stays on stdout
- `echo "required_status_checks already up-to-date ..." >&2` — status message to stderr
- `echo "Updated required_status_checks ..." >&2` — completion message to stderr

## Verification

- `shfmt -w scripts/*.sh` — no formatting changes
- `shellcheck scripts/*.sh` — passes
- `actionlint` — passes
- `./scripts/configure-branch-ruleset.sh --dry-run | jq .` now parses cleanly
