### PR TITLE
Use exit 2 for update-version usage errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -208,3 +208,6 @@ jobs:
 
       - name: stops command group when wrapper receives SIGTERM
         run: bash scripts/test-run-with-timeout-signals.sh
+
+      - name: uses exit 2 for update-version usage errors
+        run: bash scripts/test-update-version-usage.sh

--- a/scripts/test-update-version-usage.sh
+++ b/scripts/test-update-version-usage.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="scripts/update-version.sh"
+
+expect_usage_error() {
+	local description="$1"
+	local expected="$2"
+	shift 2
+
+	local output
+	local status
+	set +e
+	output="$("$@" 2>&1 >/dev/null)"
+	status=$?
+	set -e
+
+	if [ "${status}" -ne 2 ]; then
+		echo "${description}: expected exit 2, got ${status}" >&2
+		printf '%s\n' "${output}" >&2
+		exit 1
+	fi
+	if ! grep -F -- "${expected}" <<<"${output}" >/dev/null; then
+		echo "${description}: expected diagnostic containing '${expected}'" >&2
+		printf '%s\n' "${output}" >&2
+		exit 1
+	fi
+}
+
+expect_usage_error "missing version" "usage:" env -u GITIGNORE_IN_VERSION "$script"
+expect_usage_error "invalid argument version" "version must use vMAJOR.MINOR.PATCH format: not-a-version" "$script" not-a-version
+expect_usage_error "invalid environment version" "version must use vMAJOR.MINOR.PATCH format: not-a-version" env GITIGNORE_IN_VERSION=not-a-version "$script"

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 version="${1:-${GITIGNORE_IN_VERSION:-}}"
 if [ -z "${version}" ]; then
 	echo "usage: $0 <version>" >&2
-	exit 1
+	exit 2
 fi
 
 if ! [[ "${version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 	echo "version must use vMAJOR.MINOR.PATCH format: ${version}" >&2
-	exit 1
+	exit 2
 fi
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Summary
- return exit 2 for usage errors in `scripts/update-version.sh`
- add `scripts/test-update-version-usage.sh` for missing and invalid version inputs
- run the usage-error test from the existing helper job in `.github/workflows/main.yml`

## Validation
- `bash scripts/test-update-version-usage.sh`
- `bash scripts/test-run-with-timeout-signals.sh` (setsid-dependent branch skipped on macOS)
- `git diff --check`
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `shellcheck scripts/*.sh`
- `typos`
