### PR TITLE
Ignore leading-whitespace-only gitignore diffs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,6 +96,9 @@ jobs:
           "${GITHUB_WORKSPACE}/scripts/has-meaningful-gitignore-diff.sh" .gitignore
           grep '^changed=false$' "${GITHUB_OUTPUT}"
 
+      - name: gitignore diff helper regression tests
+        run: bash scripts/test-has-meaningful-gitignore-diff.sh
+
       - name: missing final newline diff is ignored
         run: |
           tmpdir=$(mktemp -d)

--- a/scripts/has-meaningful-gitignore-diff.sh
+++ b/scripts/has-meaningful-gitignore-diff.sh
@@ -19,12 +19,26 @@ if git diff --ignore-space-at-eol -- "${target}" |
 		/^diff --git / { in_hunk = 0; next }
 		/^@@ / { in_hunk = 1; next }
 		in_hunk && /^[+-]/ {
+			sign = substr($0, 1, 1)
 			content = substr($0, 2)
-			if (content !~ /^[[:space:]]*(#|$)/) {
-				found = 1
+			sub(/^[[:space:]]+/, "", content)
+			if (content !~ /^(#|$)/) {
+				keys[content] = 1
+				if (sign == "-") {
+					removed[content]++
+				} else {
+					added[content]++
+				}
 			}
 		}
-		END { exit found ? 0 : 1 }
+		END {
+			for (content in keys) {
+				if (removed[content] != added[content]) {
+					found = 1
+				}
+			}
+			exit found ? 0 : 1
+		}
 	'; then
 	echo "changed=true" >>"${GITHUB_OUTPUT:-/dev/stdout}"
 else

--- a/scripts/test-has-meaningful-gitignore-diff.sh
+++ b/scripts/test-has-meaningful-gitignore-diff.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+helper="${repo_root}/scripts/has-meaningful-gitignore-diff.sh"
+
+run_tracked_case() {
+	local name="$1"
+	local expected="$2"
+	local initial="$3"
+	local updated="$4"
+	local tmpdir
+
+	tmpdir="$(mktemp -d)"
+	(
+		trap 'rm -rf "${tmpdir}"' EXIT
+		cd "${tmpdir}"
+
+		git init --quiet
+		git config user.name test
+		git config user.email test@example.com
+		printf '%s' "${initial}" >.gitignore
+		git add .gitignore
+		git commit --quiet -m init
+		printf '%s' "${updated}" >.gitignore
+
+		GITHUB_OUTPUT="${tmpdir}/output.txt" "${helper}" .gitignore
+		if ! grep -qx "changed=${expected}" "${tmpdir}/output.txt"; then
+			echo "${name}: expected changed=${expected}" >&2
+			cat "${tmpdir}/output.txt" >&2
+			exit 1
+		fi
+	)
+}
+
+run_tracked_case \
+	"leading whitespace-only pattern diff is ignored" \
+	false \
+	$'node_modules/\n.env\n' \
+	$'node_modules/\n  .env\n'
+
+run_tracked_case \
+	"changed pattern is meaningful" \
+	true \
+	$'node_modules/\n.env\n' \
+	$'node_modules/\nbuild/\n'


### PR DESCRIPTION
## Summary
- Normalize changed `.gitignore` hunk entries by comparing non-comment patterns after trimming leading whitespace.
- Keep comment-only, blank-only, final-newline-only, and untracked-file behavior unchanged.
- Add a regression script for leading-whitespace-only pattern changes and run it from the diff-detection workflow.

## Tests
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `shellcheck scripts/*.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `bash scripts/test-has-meaningful-gitignore-diff.sh`
- Manual helper cases for comment-only, blank-only, final-newline-only, meaningful, plus/minus-prefixed, and untracked `.gitignore` diffs
