### PR TITLE
Expose boilerplates provenance in generated PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ To produce reproducible `.gitignore` output, pass a specific commit SHA:
     boilerplates_ref: "abc1234"  # SHA from github.com/toptal/gitignore
 ```
 
+When `boilerplates_ref` is omitted, the action warns that the boilerplates
+database will follow the latest commit on each run. In all cases, generated
+PR bodies include the boilerplates database commit SHA used for that run so the
+provenance is visible in the pull request.
+
 ### Adjusting the generation timeout
 
 The `gitignore.in` generation step times out after 300 seconds by default.
@@ -102,7 +107,7 @@ Tune the value when a runner needs a shorter fail-fast limit or more time to
 fetch and render large templates:
 
 ```yaml
-- uses: gitignore-in/gh-action@main
+- uses: gitignore-in/gh-action
   with:
     timeout_seconds: "120"
 ```

--- a/action.yml
+++ b/action.yml
@@ -48,8 +48,9 @@ inputs:
       Optional git ref (branch, tag, or full SHA) for the gitignore boilerplates
       database (github.com/toptal/gitignore). When set, the boilerplates database
       is checked out at this ref after the update, making .gitignore generation
-      reproducible across runs. Leave empty to use the latest commit (default
-      behaviour, non-deterministic).
+      reproducible across runs and recording that pinned commit SHA in generated
+      pull request bodies. Leave empty to use the latest commit (default
+      behaviour, non-deterministic); the action warns when this input is omitted.
     required: false
     default: ""
   gitignore-version:
@@ -108,6 +109,11 @@ runs:
     - uses: gitignore-in/install-gibo@190df5cc5be7f64b8364a04f9c84e2cfa7b1cd32 # main
       with:
         boilerplates-ref: ${{ inputs.boilerplates_ref }}
+    - name: warn when boilerplates_ref is not set
+      if: inputs.boilerplates_ref == ''
+      run: |
+        echo "::warning::boilerplates_ref is not set; generated pull requests will record the latest boilerplates database commit SHA, but the generated .gitignore may vary between runs."
+      shell: bash
     - run: |
         "${GITHUB_ACTION_PATH}/scripts/install-gitignore-in.sh"
       env:
@@ -127,6 +133,26 @@ runs:
       id: boilerplates_ref
       run: |
         "${GITHUB_ACTION_PATH}/scripts/capture-boilerplates-ref.sh"
+      shell: bash
+
+    - name: compose pull request body
+      id: pr_body
+      env:
+        INPUT_PR_BODY: ${{ inputs.pr_body }}
+        BOILERPLATES_REF: ${{ steps.boilerplates_ref.outputs.boilerplates-ref }}
+      run: |
+        body_file="${RUNNER_TEMP}/gitignore-in-pr-body.md"
+        {
+          if [ -n "${INPUT_PR_BODY}" ]; then
+            printf '%s\n\n' "${INPUT_PR_BODY}"
+          fi
+          if [ -n "${BOILERPLATES_REF}" ]; then
+            printf 'Boilerplates database commit SHA: %s\n' "${BOILERPLATES_REF}"
+          else
+            printf 'Boilerplates database commit SHA: unavailable\n'
+          fi
+        } >"${body_file}"
+        echo "body-path=${body_file}" >> "${GITHUB_OUTPUT}"
       shell: bash
 
     - name: check .gitignore
@@ -154,6 +180,6 @@ runs:
         commit-message: ${{ inputs.commit_message }}
         delete-branch: ${{ inputs.delete_branch }}
         title: ${{ inputs.pr_title }}
-        body: ${{ inputs.pr_body }}
+        body-path: ${{ steps.pr_body.outputs.body-path }}
       env:
         GH_TOKEN: ${{ github.token }}

--- a/action.yml
+++ b/action.yml
@@ -60,14 +60,14 @@ inputs:
       This input selects the release artifact only; checksum policy is
       controlled separately by allow-unverified-gitignore-version.
     required: false
-    default: !!str v0.2.1
+    default: "v0.2.1"
   allow-unverified-gitignore-version:
     description: |
       Allow a custom gitignore-version without SHA-256 verification.
       Leave false to reject unverified custom versions and keep the bundled
       release checksum-verified.
     required: false
-    default: !!str false
+    default: "false"
   timeout_seconds:
     description: |
       Positive timeout in seconds for the gitignore.in generation step.

--- a/action.yml
+++ b/action.yml
@@ -60,14 +60,14 @@ inputs:
       This input selects the release artifact only; checksum policy is
       controlled separately by allow-unverified-gitignore-version.
     required: false
-    default: "v0.2.1"
+    default: !!str v0.2.1
   allow-unverified-gitignore-version:
     description: |
       Allow a custom gitignore-version without SHA-256 verification.
       Leave false to reject unverified custom versions and keep the bundled
       release checksum-verified.
     required: false
-    default: "false"
+    default: !!str false
   timeout_seconds:
     description: |
       Positive timeout in seconds for the gitignore.in generation step.


### PR DESCRIPTION
Summary:
- warn when `boilerplates_ref` is not set
- append the boilerplates database commit SHA to generated PR bodies
- document the warning and generated PR body provenance

Verification:
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `shellcheck scripts/*.sh`
- `typos README.md action.yml`
- `git diff --check`
