### PR TITLE
fix: update version extraction patterns to match bundled_version= format

### DIFF
--- a/scripts/check-version-sha256-coherence.sh
+++ b/scripts/check-version-sha256-coherence.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 # Verify that the version referenced in action.yml matches every entry in
-# bundled-binary.sha256. When a Renovate PR updates only the version= line in
-# action.yml without regenerating bundled-binary.sha256, the download step fails
-# at workflow runtime because grep finds no matching checksum line.
+# bundled-binary.sha256. When a Renovate PR updates only the bundled_version=
+# line in action.yml without regenerating bundled-binary.sha256, the download
+# step fails at workflow runtime because grep finds no matching checksum line.
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/.." && pwd)"
@@ -12,9 +12,9 @@ repo_root="$(cd "${script_dir}/.." && pwd)"
 action_file="${repo_root}/action.yml"
 sha256_file="${repo_root}/bundled-binary.sha256"
 
-action_version="$(grep -E '^\s+version=v[0-9]+\.[0-9]+\.[0-9]+$' "${action_file}" | sed -E 's/.*version=(v[0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+action_version="$(grep -E '^\s+bundled_version="v[0-9]+\.[0-9]+\.[0-9]+"$' "${action_file}" | sed -E 's/.*bundled_version="(v[0-9]+\.[0-9]+\.[0-9]+)".*/\1/')"
 if [ -z "${action_version}" ]; then
-	echo "ERROR: could not extract version= from ${action_file}" >&2
+	echo "ERROR: could not extract bundled_version= from ${action_file}" >&2
 	exit 1
 fi
 echo "action.yml version: ${action_version}"

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -77,10 +77,11 @@ done
 # both into the repo after they have both been produced successfully.
 staging_action="${tmpdir}/action.yml"
 sed -E \
-	-e "s/version=v[0-9]+\\.[0-9]+\\.[0-9]+$/version=${version}/" \
+	-e "s/bundled_version=\"v[0-9]+\\.[0-9]+\\.[0-9]+\"/bundled_version=\"${version}\"/" \
+	-e "s/^(    default: )\"v[0-9]+\\.[0-9]+\\.[0-9]+\"$/\\1\"${version}\"/" \
 	"${action_file}" >"${staging_action}"
-if ! grep -qF "version=${version}" "${staging_action}"; then
-	echo "action.yml version= line did not update to ${version}" >&2
+if ! grep -qF "bundled_version=\"${version}\"" "${staging_action}"; then
+	echo "action.yml bundled_version= line did not update to ${version}" >&2
 	exit 1
 fi
 


### PR DESCRIPTION
## Problem

PR #103 added the `gitignore-version` input and changed `action.yml` to use:

```yaml
bundled_version="v0.2.1"
```

as a shell variable (with double-quote wrapping and a `bundled_` prefix). However, two scripts added by PR #98 and the release workflow still referenced the old `version=v...` pattern, breaking CI and the release-update automation.

## Changes

### `scripts/check-version-sha256-coherence.sh`

Updated grep/sed patterns from `version=v...` to `bundled_version="v..."`:

```diff
-action_version="$(grep -E '^\s+version=v[0-9]+\.[0-9]+\.[0-9]+$' "${action_file}" | sed -E 's/.*version=(v[0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+action_version="$(grep -E '^\s+bundled_version="v[0-9]+\.[0-9]+\.[0-9]+"$' "${action_file}" | sed -E 's/.*bundled_version="(v[0-9]+\.[0-9]+\.[0-9]+)".*/\1/')"
 if [ -z "${action_version}" ]; then
-    echo "ERROR: could not extract version= from ${action_file}" >&2
+    echo "ERROR: could not extract bundled_version= from ${action_file}" >&2
```

### `scripts/update-version.sh`

Updated sed/grep patterns to match the new format, and added a second sed substitution to also update the `default:` value in the `gitignore-version` input section:

```diff
-sed -E \
-    -e "s/version=v[0-9]+\\.[0-9]+\\.[0-9]+$/version=${version}/" \
-    "${action_file}" >"${staging_action}"
-if \! grep -qF "version=${version}" "${staging_action}"; then
-    echo "action.yml version= line did not update to ${version}" >&2
+sed -E \
+    -e "s/bundled_version=\"v[0-9]+\\.[0-9]+\\.[0-9]+\"/bundled_version=\"${version}\"/" \
+    -e "s/^(    default: )\"v[0-9]+\\.[0-9]+\\.[0-9]+\"$/\\1\"${version}\"/" \
+    "${action_file}" >"${staging_action}"
+if \! grep -qF "bundled_version=\"${version}\"" "${staging_action}"; then
+    echo "action.yml bundled_version= line did not update to ${version}" >&2
```

### `.github/workflows/prepare-release-update.yml` (manual step required)

The PAT used to create this PR does not have `workflow` scope, so this file could not be pushed automatically. Please apply this patch manually:

```diff
-          version="$(grep -E '^[[:space:]]*version=v[0-9]+\.[0-9]+\.[0-9]+$' action.yml | head -n1 | cut -d= -f2)"
+          version="$(grep -E '^[[:space:]]*bundled_version="v[0-9]+\.[0-9]+\.[0-9]+"$' action.yml | head -n1 | sed -E 's/.*bundled_version="(v[0-9]+\.[0-9]+\.[0-9]+)".*/\1/')"
```

(Line 89 in the `validate` job's "Download bundled release artifact" step.)

## Verification

```
$ bash scripts/check-version-sha256-coherence.sh
action.yml version: v0.2.1
bundled-binary.sha256: 4/4 entries match v0.2.1
OK: all 4 entries in bundled-binary.sha256 are coherent with v0.2.1
```