### PR TITLE
Add diagnostic error message when version extraction fails

### DIFF
--- a/scripts/check-version-sha256-coherence.sh
+++ b/scripts/check-version-sha256-coherence.sh
@@ -12,9 +12,10 @@ repo_root="$(cd "${script_dir}/.." && pwd)"
 action_file="${repo_root}/action.yml"
 sha256_file="${repo_root}/bundled-binary.sha256"
 
-action_version="$(grep -E '^\s+bundled_version="v[0-9]+\.[0-9]+\.[0-9]+"$' "${action_file}" | sed -E 's/.*bundled_version="(v[0-9]+\.[0-9]+\.[0-9]+)".*/\1/')"
+action_version="$(grep -E '^\s+bundled_version="v[0-9]+\.[0-9]+\.[0-9]+"$' "${action_file}" | sed -E 's/.*bundled_version="(v[0-9]+\.[0-9]+\.[0-9]+)".*/\1/' || true)"
 if [ -z "${action_version}" ]; then
 	echo "ERROR: could not extract bundled_version= from ${action_file}" >&2
+	echo "       grep pattern: '^\s+bundled_version=\"v[0-9]+\.[0-9]+\.[0-9]+\"\$'" >&2
 	exit 1
 fi
 echo "action.yml version: ${action_version}"


### PR DESCRIPTION
## Summary

`check-version-sha256-coherence.sh` contains a guard clause that is supposed to catch cases where version extraction from `action.yml` fails — but with `set -euo pipefail` active, the `grep | sed` pipeline's non-zero exit code terminates the script via `set -e` before reaching that guard, and the `grep` pattern used is not visible in the error output.

This PR makes two improvements to that script:

- Add `|| true` to the pipeline so a grep-no-match exits cleanly and lets the explicit guard clause run (rather than being pre-empted by `set -e`).
- Include the grep pattern in the error message so the root cause is immediately visible in CI logs without manual cross-referencing.

## Changes

- `scripts/check-version-sha256-coherence.sh`: `|| true` on the `grep | sed` pipeline; adds grep pattern to the `ERROR:` output line.

## Note

The `validate` job in `prepare-release-update.yml` has the same structural gap (version extraction without an explicit empty guard). That change requires a token with `workflow` scope and is not included here.

## Test plan

- [ ] `shell-format` (`shfmt`) passes: no formatting changes to the script.
- [ ] `shell-lint` (`shellcheck`) passes: no new warnings.
- [ ] `version-coherence` job runs and produces the improved error message.
