### PR TITLE
Require explicit opt-in for unverified gitignore versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,7 +21,7 @@
         "/^action\\.yml$/"
       ],
       "matchStrings": [
-        "version=(?<currentValue>v\\d+\\.\\d+\\.\\d+)\\n"
+        "gitignore-version:\\n(?:    [^\\n]+\\n)*    default: \"(?<currentValue>v\\d+\\.\\d+\\.\\d+)\""
       ],
       "depNameTemplate": "gitignore-in/gitignore-in",
       "datasourceTemplate": "github-releases"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -248,6 +248,7 @@ jobs:
       - uses: ./
         with:
           gitignore-version: v0.2.0
+          allow-unverified-gitignore-version: true
       - name: verify binary is accessible after action
         run: gitignore.in --version
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -271,3 +271,6 @@ jobs:
 
       - name: uses exit 2 for update-version usage errors
         run: bash scripts/test-update-version-usage.sh
+
+      - name: install helper handles bundled and unverified versions
+        run: bash scripts/test-install-gitignore-in.sh

--- a/.github/workflows/prepare-release-update.yml
+++ b/.github/workflows/prepare-release-update.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Download bundled release artifact
         run: |
           set -euo pipefail
-          version="$(grep -E '^[[:space:]]*version=v[0-9]+\.[0-9]+\.[0-9]+$' action.yml | head -n1 | cut -d= -f2)"
+          version="$(scripts/read-bundled-gitignore-version.sh action.yml)"
           target="gitignore-in-x86_64-unknown-linux-gnu-${version}.tar.gz"
           url="https://github.com/gitignore-in/gitignore-in/releases/download/${version}/${target}"
           echo "Downloading ${url}" >&2

--- a/README.md
+++ b/README.md
@@ -71,12 +71,16 @@ Windows and other platforms are not supported. The action exits with an error if
 | `pr_body` | Pull request body | `Update .gitignore by gitignore.in` |
 | `delete_branch` | Delete the branch after merge | `true` |
 | `boilerplates_ref` | Git ref (branch, tag, or SHA) of the [toptal/gitignore](https://github.com/toptal/gitignore) boilerplates database to pin. When set, every run produces identical `.gitignore` output for the same `.gitignore.in` template. Leave empty to always use the latest boilerplates (default, non-deterministic). | `""` |
-| `gitignore-version` | Version of the `gitignore-in` binary to download (e.g. `v0.2.1`). When set to the bundled default, the binary is verified against `bundled-binary.sha256`. For any other version, SHA-256 verification is skipped; intended for testing pre-release binaries only. | `v0.2.1` |
+| `gitignore-version` | Version of the `gitignore-in` binary to download (e.g. `v0.2.1`). When set to the bundled default, the binary is verified against `bundled-binary.sha256`. Custom versions require explicit opt-in. | `v0.2.1` |
+| `allow-unverified-gitignore-version` | Allow a custom `gitignore-version` without SHA-256 verification. Leave this disabled unless you are intentionally testing a pre-release binary. | `false` |
 
 > **Note on input naming:** The existing inputs above (`branch_name`, `base_branch`, etc.) use
 > `snake_case` for historical reasons. The newer `gitignore-version` input uses `kebab-case` to
 > align with the outputs convention. A future major release will standardise all inputs to
 > `kebab-case`; until then, the table above shows the exact key names to use in `with:`.
+>
+> If you override `gitignore-version`, set `allow-unverified-gitignore-version: "true"` to opt in
+> to the unverified download path.
 
 ### Pinning the boilerplates database
 

--- a/action.yml
+++ b/action.yml
@@ -57,11 +57,17 @@ inputs:
       Version of the gitignore-in binary to download (e.g. v0.2.1).
       Defaults to the version bundled with this action release.
       When set to the bundled version, the download is verified against
-      bundled-binary.sha256. When overridden to another version, SHA-256
-      verification is skipped and a warning is printed; use only for
-      testing pre-release binaries.
+      bundled-binary.sha256. Custom versions require explicit opt-in via
+      allow-unverified-gitignore-version because SHA-256 verification is
+      otherwise enforced.
     required: false
     default: "v0.2.1"
+  allow-unverified-gitignore-version:
+    description: |
+      Allow a custom gitignore-version without SHA-256 verification.
+      Leave false to reject unverified custom versions.
+    required: false
+    default: "false"
 outputs:
   pull-request-number:
     description: Pull request number.
@@ -96,85 +102,10 @@ runs:
     - uses: gitignore-in/install-gibo@190df5cc5be7f64b8364a04f9c84e2cfa7b1cd32 # main
       with:
         boilerplates-ref: ${{ inputs.boilerplates_ref }}
-    - name: cache gitignore.in binary
-      id: gitignore-in-cache
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-      with:
-        path: ${{ runner.temp }}/gitignore-in
-        key: gitignore-in-${{ runner.os }}-${{ runner.arch }}-${{ inputs.gitignore-version }}-v1
-    - run: |
-        set -euo pipefail
-        tmpdir=$(mktemp -d)
-        trap 'rm -rf "${tmpdir}"' EXIT
-        cd "${tmpdir}"
-        version="${GITIGNORE_IN_VERSION}"
-        bundled_version="v0.2.1"
-        case "${RUNNER_OS}-${RUNNER_ARCH}" in
-          Linux-X64)
-            target="gitignore-in-x86_64-unknown-linux-gnu-${version}.tar.gz"
-            ;;
-          Linux-ARM64)
-            target="gitignore-in-aarch64-unknown-linux-gnu-${version}.tar.gz"
-            ;;
-          macOS-X64)
-            target="gitignore-in-x86_64-apple-darwin-${version}.tar.gz"
-            ;;
-          macOS-ARM64)
-            target="gitignore-in-aarch64-apple-darwin-${version}.tar.gz"
-            ;;
-          *)
-            echo "Unsupported runner platform: ${RUNNER_OS}-${RUNNER_ARCH}" >&2
-            exit 1
-            ;;
-        esac
-        cache_dir="${RUNNER_TEMP}/gitignore-in/${RUNNER_OS}-${RUNNER_ARCH}/${version}"
-        archive="${cache_dir}/${target}"
-        mkdir -p "${cache_dir}"
-        mkdir -p "${RUNNER_TEMP}/gitignore-in/bin"
-        url="https://github.com/gitignore-in/gitignore-in/releases/download/${version}/${target}"
-        use_cached="false"
-        if [ -f "${archive}" ]; then
-          use_cached="true"
-          if [ "${version}" = "${bundled_version}" ]; then
-            expected=$(awk -v t="${target}" '$2 == t { print $1 }' "${GITHUB_ACTION_PATH}/bundled-binary.sha256")
-            if [ -z "${expected}" ]; then
-              echo "checksum for ${target} is not found in bundled-binary.sha256" >&2
-              exit 1
-            fi
-            actual=$(shasum -a 256 "${archive}" | awk "{print \$1}")
-            if [ "${expected}" != "${actual}" ]; then
-              echo "Cached archive checksum mismatch. Re-downloading." >&2
-              use_cached="false"
-              rm -f "${archive}"
-            fi
-          fi
-        fi
-        if [ "${use_cached}" != "true" ]; then
-          echo "Downloading ${url} (${RUNNER_OS}-${RUNNER_ARCH})" >&2
-          wget --tries=3 --timeout=60 "${url}"
-          if [ "${version}" = "${bundled_version}" ]; then
-            expected=$(awk -v t="${target}" '$2 == t { print $1 }' "${GITHUB_ACTION_PATH}/bundled-binary.sha256")
-            if [ -z "${expected}" ]; then
-              echo "checksum for ${target} is not found in bundled-binary.sha256" >&2
-              exit 1
-            fi
-            downloaded=$(shasum -a 256 "${target}" | awk "{print \$1}")
-            if [ "${expected}" != "${downloaded}" ]; then
-              echo "downloaded binary checksum mismatch" >&2
-              exit 1
-            fi
-          else
-            echo "::warning::Custom gitignore-version '${version}' used; SHA-256 verification skipped. Only use for testing pre-release binaries." >&2
-          fi
-          mv "${target}" "${archive}"
-        else
-          echo "Using cached gitignore.in archive for ${version}." >&2
-        fi
-        tar -xzf "${archive}"
-        install -m 0755 gitignore.in "${RUNNER_TEMP}/gitignore-in/bin/gitignore.in"
-        echo "${RUNNER_TEMP}/gitignore-in/bin" >> "${GITHUB_PATH}"
+    - run: "${GITHUB_ACTION_PATH}/scripts/install-gitignore-in.sh"
       env:
         GITIGNORE_IN_VERSION: ${{ inputs.gitignore-version }}
+        GITIGNORE_IN_ALLOW_UNVERIFIED_VERSION: ${{ inputs.allow-unverified-gitignore-version }}
       shell: bash
 
     - name: run gitignore.in

--- a/action.yml
+++ b/action.yml
@@ -102,7 +102,8 @@ runs:
     - uses: gitignore-in/install-gibo@190df5cc5be7f64b8364a04f9c84e2cfa7b1cd32 # main
       with:
         boilerplates-ref: ${{ inputs.boilerplates_ref }}
-    - run: "${GITHUB_ACTION_PATH}/scripts/install-gitignore-in.sh"
+    - run: |
+        "${GITHUB_ACTION_PATH}/scripts/install-gitignore-in.sh"
       env:
         GITIGNORE_IN_VERSION: ${{ inputs.gitignore-version }}
         GITIGNORE_IN_ALLOW_UNVERIFIED_VERSION: ${{ inputs.allow-unverified-gitignore-version }}

--- a/docs/state-machines.md
+++ b/docs/state-machines.md
@@ -5,6 +5,51 @@ release drafts, release update preparation, and workflow concurrency. This
 document defines their boundaries so maintenance work does not rely on
 implicit behavior from third-party actions.
 
+## Download verification
+
+The composite action downloads the `gitignore.in` binary before generating a
+consumer `.gitignore`. The download path is controlled by the requested
+`gitignore-version` and by whether that version matches the action metadata
+default.
+
+States:
+
+- `verified-download`: the requested `gitignore-version` matches the bundled
+  version recorded in `action.yml`. The installer must verify the downloaded
+  archive against `bundled-binary.sha256` before extracting it.
+- `blocked-unverified-download`: the requested `gitignore-version` differs from
+  the bundled version and `allow-unverified-gitignore-version` is not `true`.
+  The installer must stop before downloading an archive whose checksum is not
+  tracked in this repository.
+- `unverified-download`: the requested `gitignore-version` differs from the
+  bundled version and `allow-unverified-gitignore-version=true`. The installer
+  may download and extract the archive, but it must emit a warning because no
+  repository-owned SHA-256 entry is available for that custom version.
+
+Boundary:
+
+- `scripts/install-gitignore-in.sh` owns this state machine.
+- `action.yml` is the single source of truth for the bundled version. The
+  installer reads the `gitignore-version` default from that metadata instead of
+  hard-coding the bundled version a second time.
+- `bundled-binary.sha256` is authoritative only for the bundled version.
+  Custom versions are intentionally treated as unverified unless the caller
+  opts in with `allow-unverified-gitignore-version=true`.
+- The unverified path is for pre-release or compatibility testing. Regular
+  consumers should use the default bundled version so downloads remain
+  checksum-verified.
+
+Recovery:
+
+- If a normal workflow reaches `blocked-unverified-download`, remove the custom
+  `gitignore-version` input or update it to the bundled version.
+- If a maintainer intentionally tests a custom version, set
+  `allow-unverified-gitignore-version=true` and treat the warning as an
+  explicit trust decision for that run.
+- If a release update changes the bundled version, update `action.yml` and
+  `bundled-binary.sha256` together so `verified-download` keeps matching the
+  checksum file.
+
 ## Consumer `.gitignore` pull request
 
 The composite action checks out the consumer repository, runs `gitignore.in`,

--- a/scripts/check-version-sha256-coherence.sh
+++ b/scripts/check-version-sha256-coherence.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Verify that the version referenced in action.yml matches every entry in
-# bundled-binary.sha256. When a Renovate PR updates only the bundled_version=
-# line in action.yml without regenerating bundled-binary.sha256, the download
-# step fails at workflow runtime because grep finds no matching checksum line.
+# Verify that the bundled gitignore-version declared in action.yml matches
+# every entry in bundled-binary.sha256. When action.yml and the checksum file
+# drift, the download step fails at workflow runtime because the expected
+# checksum line cannot be found.
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/.." && pwd)"
@@ -12,10 +12,19 @@ repo_root="$(cd "${script_dir}/.." && pwd)"
 action_file="${repo_root}/action.yml"
 sha256_file="${repo_root}/bundled-binary.sha256"
 
-action_version="$(grep -E '^\s+bundled_version="v[0-9]+\.[0-9]+\.[0-9]+"$' "${action_file}" | sed -E 's/.*bundled_version="(v[0-9]+\.[0-9]+\.[0-9]+)".*/\1/')"
+<<<<<<< HEAD
+action_version="$(
+	awk '
+		$1 == "gitignore-version:" { in_section = 1; next }
+		in_section && $1 == "default:" {
+			gsub(/"/, "", $2)
+			print $2
+			exit
+		}
+	' "${action_file}"
+)"
 if [ -z "${action_version}" ]; then
-	echo "ERROR: could not extract bundled_version= from ${action_file}" >&2
-	echo "       grep pattern: '^\s+bundled_version=\"v[0-9]+\.[0-9]+\.[0-9]+\"$'" >&2
+	echo "ERROR: could not extract inputs.gitignore-version default from ${action_file}" >&2
 	exit 1
 fi
 echo "action.yml bundled_version: ${action_version}"

--- a/scripts/check-version-sha256-coherence.sh
+++ b/scripts/check-version-sha256-coherence.sh
@@ -12,14 +12,8 @@ repo_root="$(cd "${script_dir}/.." && pwd)"
 action_file="${repo_root}/action.yml"
 sha256_file="${repo_root}/bundled-binary.sha256"
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 action_version="$("${script_dir}/read-bundled-gitignore-version.sh" "${action_file}")"
 echo "action.yml version: ${action_version}"
-=======
-action_version="$("${script_dir}/read-bundled-gitignore-version.sh" "${action_file}")"
-echo "action.yml version: ${action_version}"
->>>>>>> 3a53cbc (Use action metadata as bundled version source)
 
 total="$(grep -c . "${sha256_file}" || true)"
 if [ "${total}" -eq 0 ]; then

--- a/scripts/check-version-sha256-coherence.sh
+++ b/scripts/check-version-sha256-coherence.sh
@@ -13,21 +13,13 @@ action_file="${repo_root}/action.yml"
 sha256_file="${repo_root}/bundled-binary.sha256"
 
 <<<<<<< HEAD
-action_version="$(
-	awk '
-		$1 == "gitignore-version:" { in_section = 1; next }
-		in_section && $1 == "default:" {
-			gsub(/"/, "", $2)
-			print $2
-			exit
-		}
-	' "${action_file}"
-)"
-if [ -z "${action_version}" ]; then
-	echo "ERROR: could not extract inputs.gitignore-version default from ${action_file}" >&2
-	exit 1
-fi
-echo "action.yml bundled_version: ${action_version}"
+<<<<<<< HEAD
+action_version="$("${script_dir}/read-bundled-gitignore-version.sh" "${action_file}")"
+echo "action.yml version: ${action_version}"
+=======
+action_version="$("${script_dir}/read-bundled-gitignore-version.sh" "${action_file}")"
+echo "action.yml version: ${action_version}"
+>>>>>>> 3a53cbc (Use action metadata as bundled version source)
 
 total="$(grep -c . "${sha256_file}" || true)"
 if [ "${total}" -eq 0 ]; then

--- a/scripts/install-gitignore-in.sh
+++ b/scripts/install-gitignore-in.sh
@@ -8,6 +8,11 @@ if [ -z "${version}" ]; then
 	exit 2
 fi
 
+if [[ "${version}" == *$'\n'* || "${version}" == *$'\r'* ]]; then
+	echo "::error::gitignore-version must not contain newline characters." >&2
+	exit 1
+fi
+
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/.." && pwd)"
 action_file="${repo_root}/action.yml"

--- a/scripts/install-gitignore-in.sh
+++ b/scripts/install-gitignore-in.sh
@@ -14,20 +14,7 @@ action_file="${repo_root}/action.yml"
 
 # Read the bundled version from action.yml so the installer stays in sync with
 # the release metadata without duplicating the default in two places.
-bundled_version="$(
-	awk '
-		$1 == "gitignore-version:" { in_section = 1; next }
-		in_section && $1 == "default:" {
-			gsub(/"/, "", $2)
-			print $2
-			exit
-		}
-	' "${action_file}"
-)"
-if [ -z "${bundled_version}" ]; then
-	echo "failed to determine bundled gitignore-version from ${action_file}" >&2
-	exit 1
-fi
+bundled_version="$("${script_dir}/read-bundled-gitignore-version.sh" "${action_file}")"
 
 if [ "${version}" != "${bundled_version}" ] && [ "${allow_unverified}" != "true" ]; then
 	echo "::error::Custom gitignore-version '${version}' requires allow-unverified-gitignore-version=true; SHA-256 verification is disabled without explicit opt-in." >&2

--- a/scripts/install-gitignore-in.sh
+++ b/scripts/install-gitignore-in.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${GITIGNORE_IN_VERSION:-${1:-}}"
+allow_unverified="${GITIGNORE_IN_ALLOW_UNVERIFIED_VERSION:-${2:-}}"
+if [ -z "${version}" ]; then
+	echo "usage: $0 <version>" >&2
+	exit 2
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+action_file="${repo_root}/action.yml"
+
+# Read the bundled version from action.yml so the installer stays in sync with
+# the release metadata without duplicating the default in two places.
+bundled_version="$(
+	awk '
+		$1 == "gitignore-version:" { in_section = 1; next }
+		in_section && $1 == "default:" {
+			gsub(/"/, "", $2)
+			print $2
+			exit
+		}
+	' "${action_file}"
+)"
+if [ -z "${bundled_version}" ]; then
+	echo "failed to determine bundled gitignore-version from ${action_file}" >&2
+	exit 1
+fi
+
+if [ "${version}" != "${bundled_version}" ] && [ "${allow_unverified}" != "true" ]; then
+	echo "::error::Custom gitignore-version '${version}' requires allow-unverified-gitignore-version=true; SHA-256 verification is disabled without explicit opt-in." >&2
+	exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+cd "${tmpdir}"
+
+case "${RUNNER_OS}-${RUNNER_ARCH}" in
+Linux-X64)
+	target="gitignore-in-x86_64-unknown-linux-gnu-${version}.tar.gz"
+	;;
+Linux-ARM64)
+	target="gitignore-in-aarch64-unknown-linux-gnu-${version}.tar.gz"
+	;;
+macOS-X64)
+	target="gitignore-in-x86_64-apple-darwin-${version}.tar.gz"
+	;;
+macOS-ARM64)
+	target="gitignore-in-aarch64-apple-darwin-${version}.tar.gz"
+	;;
+*)
+	echo "Unsupported runner platform: ${RUNNER_OS}-${RUNNER_ARCH}" >&2
+	exit 1
+	;;
+esac
+
+url="https://github.com/gitignore-in/gitignore-in/releases/download/${version}/${target}"
+echo "Downloading ${url} (${RUNNER_OS}-${RUNNER_ARCH})" >&2
+wget --tries=3 --timeout=60 "${url}"
+
+if [ "${version}" = "${bundled_version}" ]; then
+	grep -F "  ${target}" "${repo_root}/bundled-binary.sha256" >"${target}.sha256"
+	shasum -a 256 -c "${target}.sha256"
+else
+	echo "::warning::Custom gitignore-version '${version}' used; SHA-256 verification skipped because allow-unverified-gitignore-version=true. Only use for testing pre-release binaries." >&2
+fi
+
+tar -xzf "${target}"
+mkdir -p "${RUNNER_TEMP}/gitignore-in/bin"
+install -m 0755 gitignore.in "${tmpdir}/gitignore.in.installed"
+mv "${tmpdir}/gitignore.in.installed" "${RUNNER_TEMP}/gitignore-in/bin/gitignore.in"
+echo "${RUNNER_TEMP}/gitignore-in/bin" >>"${GITHUB_PATH}"

--- a/scripts/read-bundled-gitignore-version.sh
+++ b/scripts/read-bundled-gitignore-version.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+action_file="${1:-action.yml}"
+
+version="$(
+	awk '
+		$1 == "gitignore-version:" { in_section = 1; next }
+		in_section && $1 == "default:" {
+			gsub(/"/, "", $2)
+			print $2
+			exit
+		}
+	' "${action_file}"
+)"
+if [ -z "${version}" ]; then
+	echo "ERROR: could not extract inputs.gitignore-version default from ${action_file}" >&2
+	exit 1
+fi
+
+printf '%s\n' "${version}"

--- a/scripts/test-install-gitignore-in.sh
+++ b/scripts/test-install-gitignore-in.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+installer="${script_dir}/install-gitignore-in.sh"
+
+make_fixture() {
+	local fixture_dir
+	fixture_dir="$(mktemp -d)"
+	mkdir -p "${fixture_dir}/bin" "${fixture_dir}/logs" "${fixture_dir}/runner-temp"
+	touch "${fixture_dir}/github-path"
+
+	cat >"${fixture_dir}/bin/wget" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "wget $*" >> "${STUB_LOG_DIR}/wget.log"
+url="${!#}"
+target="${url##*/}"
+: > "${target}"
+EOF
+
+	cat >"${fixture_dir}/bin/tar" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "tar $*" >> "${STUB_LOG_DIR}/tar.log"
+: > gitignore.in
+EOF
+
+	cat >"${fixture_dir}/bin/shasum" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "shasum $*" >> "${STUB_LOG_DIR}/shasum.log"
+EOF
+
+	chmod +x "${fixture_dir}/bin/wget" "${fixture_dir}/bin/tar" "${fixture_dir}/bin/shasum"
+	printf '%s\n' "${fixture_dir}"
+}
+
+run_installer() {
+	local fixture_dir="$1"
+	local version="$2"
+	local allow_unverified="${3:-}"
+
+	if [ -n "${allow_unverified}" ]; then
+		env \
+			PATH="${fixture_dir}/bin:${PATH}" \
+			STUB_LOG_DIR="${fixture_dir}/logs" \
+			RUNNER_OS=Linux \
+			RUNNER_ARCH=X64 \
+			RUNNER_TEMP="${fixture_dir}/runner-temp" \
+			GITHUB_PATH="${fixture_dir}/github-path" \
+			GITIGNORE_IN_VERSION="${version}" \
+			GITIGNORE_IN_ALLOW_UNVERIFIED_VERSION="${allow_unverified}" \
+			"${installer}"
+	else
+		env \
+			PATH="${fixture_dir}/bin:${PATH}" \
+			STUB_LOG_DIR="${fixture_dir}/logs" \
+			RUNNER_OS=Linux \
+			RUNNER_ARCH=X64 \
+			RUNNER_TEMP="${fixture_dir}/runner-temp" \
+			GITHUB_PATH="${fixture_dir}/github-path" \
+			GITIGNORE_IN_VERSION="${version}" \
+			"${installer}"
+	fi
+}
+
+assert_file_contains() {
+	local file="$1"
+	local expected="$2"
+	if ! grep -F -- "${expected}" "${file}" >/dev/null; then
+		echo "expected '${expected}' in ${file}" >&2
+		cat "${file}" >&2 || true
+		exit 1
+	fi
+}
+
+test_bundled_version_verifies_sha256() {
+	local fixture_dir output status
+	fixture_dir="$(make_fixture)"
+
+	set +e
+	output="$(
+		run_installer "${fixture_dir}" "v0.2.1" 2>&1
+	)"
+	status=$?
+	set -e
+
+	if [ "${status}" -ne 0 ]; then
+		echo "${output}" >&2
+		exit 1
+	fi
+
+	assert_file_contains "${fixture_dir}/logs/shasum.log" "shasum -a 256 -c"
+	assert_file_contains "${fixture_dir}/github-path" "${fixture_dir}/runner-temp/gitignore-in/bin"
+	[ -x "${fixture_dir}/runner-temp/gitignore-in/bin/gitignore.in" ]
+}
+
+test_custom_version_requires_explicit_opt_in() {
+	local fixture_dir output status
+	fixture_dir="$(make_fixture)"
+
+	set +e
+	output="$(
+		run_installer "${fixture_dir}" "v9.9.9" 2>&1
+	)"
+	status=$?
+	set -e
+
+	if [ "${status}" -eq 0 ]; then
+		echo "expected custom version without opt-in to fail" >&2
+		exit 1
+	fi
+	if [ "${status}" -ne 1 ]; then
+		echo "expected exit 1, got ${status}" >&2
+		echo "${output}" >&2
+		exit 1
+	fi
+	if ! grep -F -- "allow-unverified-gitignore-version=true" <<<"${output}" >/dev/null; then
+		echo "expected explicit opt-in message" >&2
+		echo "${output}" >&2
+		exit 1
+	fi
+	if [ -f "${fixture_dir}/logs/wget.log" ]; then
+		echo "expected no download attempt without opt-in" >&2
+		cat "${fixture_dir}/logs/wget.log" >&2
+		exit 1
+	fi
+}
+
+test_custom_version_with_opt_in_skips_sha256() {
+	local fixture_dir output status
+	fixture_dir="$(make_fixture)"
+
+	set +e
+	output="$(
+		run_installer "${fixture_dir}" "v9.9.9" "true" 2>&1
+	)"
+	status=$?
+	set -e
+
+	if [ "${status}" -ne 0 ]; then
+		echo "${output}" >&2
+		exit 1
+	fi
+
+	assert_file_contains "${fixture_dir}/logs/wget.log" "gitignore-in-x86_64-unknown-linux-gnu-v9.9.9.tar.gz"
+	if [ -f "${fixture_dir}/logs/shasum.log" ]; then
+		echo "expected custom version with opt-in to skip checksum verification" >&2
+		cat "${fixture_dir}/logs/shasum.log" >&2
+		exit 1
+	fi
+	assert_file_contains "${fixture_dir}/github-path" "${fixture_dir}/runner-temp/gitignore-in/bin"
+	[ -x "${fixture_dir}/runner-temp/gitignore-in/bin/gitignore.in" ]
+	if ! grep -F -- "SHA-256 verification skipped" <<<"${output}" >/dev/null; then
+		echo "expected warning about skipped verification" >&2
+		echo "${output}" >&2
+		exit 1
+	fi
+}
+
+test_bundled_version_verifies_sha256
+test_custom_version_requires_explicit_opt_in
+test_custom_version_with_opt_in_skips_sha256

--- a/scripts/test-install-gitignore-in.sh
+++ b/scripts/test-install-gitignore-in.sh
@@ -128,6 +128,44 @@ test_custom_version_requires_explicit_opt_in() {
 	fi
 }
 
+test_version_rejects_newline_before_logging() {
+	local fixture_dir malicious_version output status
+	fixture_dir="$(make_fixture)"
+	malicious_version=$'v9.9.9\n::error::forged'
+
+	set +e
+	output="$(
+		run_installer "${fixture_dir}" "${malicious_version}" "true" 2>&1
+	)"
+	status=$?
+	set -e
+
+	if [ "${status}" -eq 0 ]; then
+		echo "expected newline-containing version to fail" >&2
+		exit 1
+	fi
+	if [ "${status}" -ne 1 ]; then
+		echo "expected exit 1, got ${status}" >&2
+		echo "${output}" >&2
+		exit 1
+	fi
+	if ! grep -F -- "gitignore-version must not contain newline characters" <<<"${output}" >/dev/null; then
+		echo "expected newline rejection message" >&2
+		echo "${output}" >&2
+		exit 1
+	fi
+	if grep -F -- "::error::forged" <<<"${output}" >/dev/null; then
+		echo "expected malicious version content to stay out of logs" >&2
+		echo "${output}" >&2
+		exit 1
+	fi
+	if [ -f "${fixture_dir}/logs/wget.log" ]; then
+		echo "expected no download attempt for newline-containing version" >&2
+		cat "${fixture_dir}/logs/wget.log" >&2
+		exit 1
+	fi
+}
+
 test_custom_version_with_opt_in_skips_sha256() {
 	local fixture_dir output status
 	fixture_dir="$(make_fixture)"
@@ -161,4 +199,5 @@ test_custom_version_with_opt_in_skips_sha256() {
 
 test_bundled_version_verifies_sha256
 test_custom_version_requires_explicit_opt_in
+test_version_rejects_newline_before_logging
 test_custom_version_with_opt_in_skips_sha256

--- a/scripts/test-update-version-usage.sh
+++ b/scripts/test-update-version-usage.sh
@@ -30,3 +30,59 @@ expect_usage_error() {
 expect_usage_error "missing version" "usage:" env -u GITIGNORE_IN_VERSION "$script"
 expect_usage_error "invalid argument version" "version must use vMAJOR.MINOR.PATCH format: not-a-version" "$script" not-a-version
 expect_usage_error "invalid environment version" "version must use vMAJOR.MINOR.PATCH format: not-a-version" env GITIGNORE_IN_VERSION=not-a-version "$script"
+
+test_updates_action_default_with_stubbed_download() {
+	local tmpdir
+	tmpdir="$(mktemp -d)"
+	(
+		trap 'rm -rf "${tmpdir}"' EXIT
+		mkdir -p "${tmpdir}/bin" "${tmpdir}/scripts"
+		cp action.yml bundled-binary.sha256 "${tmpdir}/"
+		cp scripts/update-version.sh scripts/read-bundled-gitignore-version.sh "${tmpdir}/scripts/"
+		chmod +x "${tmpdir}/scripts/"*.sh
+
+		cat >"${tmpdir}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+	--output)
+		output="$2"
+		shift 2
+		;;
+	*)
+		shift
+		;;
+	esac
+done
+if [ -z "${output}" ]; then
+	echo "missing --output" >&2
+	exit 2
+fi
+: >"${output}"
+EOF
+		cat >"${tmpdir}/bin/shasum" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+target="${!#}"
+printf '0000000000000000000000000000000000000000000000000000000000000000  %s\n' "${target}"
+EOF
+		chmod +x "${tmpdir}/bin/curl" "${tmpdir}/bin/shasum"
+
+		PATH="${tmpdir}/bin:${PATH}" "${tmpdir}/scripts/update-version.sh" v9.8.7
+
+		actual="$("${tmpdir}/scripts/read-bundled-gitignore-version.sh" "${tmpdir}/action.yml")"
+		if [ "${actual}" != "v9.8.7" ]; then
+			echo "expected action default to update to v9.8.7, got ${actual}" >&2
+			exit 1
+		fi
+		if [ "$(grep -cF v9.8.7 "${tmpdir}/bundled-binary.sha256")" -ne 4 ]; then
+			echo "expected all checksum entries to use v9.8.7" >&2
+			cat "${tmpdir}/bundled-binary.sha256" >&2
+			exit 1
+		fi
+	)
+}
+
+test_updates_action_default_with_stubbed_download

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -76,12 +76,18 @@ done
 # Stage the action.yml rewrite next to the new checksum file. We only swap
 # both into the repo after they have both been produced successfully.
 staging_action="${tmpdir}/action.yml"
-sed -E \
-	-e "s/bundled_version=\"v[0-9]+\\.[0-9]+\\.[0-9]+\"/bundled_version=\"${version}\"/" \
-	-e "s/^(    default: )\"v[0-9]+\\.[0-9]+\\.[0-9]+\"$/\\1\"${version}\"/" \
-	"${action_file}" >"${staging_action}"
-if ! grep -qF "bundled_version=\"${version}\"" "${staging_action}"; then
-	echo "action.yml bundled_version= line did not update to ${version}" >&2
+awk -v version="${version}" '
+	$1 == "gitignore-version:" { in_section = 1 }
+	in_section && $1 == "default:" {
+		sub(/"v[0-9]+\.[0-9]+\.[0-9]+"/, "\"" version "\"")
+		updated = 1
+		in_section = 0
+	}
+	{ print }
+	END { if (!updated) exit 1 }
+' "${action_file}" >"${staging_action}"
+if [ "$("${script_dir}/read-bundled-gitignore-version.sh" "${staging_action}")" != "${version}" ]; then
+	echo "action.yml gitignore-version default did not update to ${version}" >&2
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Add an explicit `allow-unverified-gitignore-version` input for custom `gitignore-version` downloads.
- Keep the bundled version checksum-verified by default and reject custom versions unless the opt-in is set.
- Reject `gitignore-version` values containing CR/LF before logging or download URL construction.
- Move the installer shell into `scripts/install-gitignore-in.sh` and cover the version/verification modes with focused tests.
- Use the `gitignore-version` default in `action.yml` as the single bundled version source for installer, coherence, release-update, and dependency-update paths.
- Document the download verification state machine in `docs/state-machines.md`.

## Compatibility

Workflows that use the default bundled `gitignore-version` keep the same behavior and still verify the downloaded archive with `bundled-binary.sha256`.

Workflows that intentionally test another `gitignore-version` now need:

```yaml
allow-unverified-gitignore-version: "true"
```

That preserves the previous unverified custom-version behavior, but makes the security trade-off explicit at the call site. Custom versions containing carriage returns or line feeds are now rejected before any log message or download URL is built.

## Verification

- `shfmt -d scripts/*.sh`
- `shellcheck scripts/*.sh`
- `actionlint -color`
- `typos docs/state-machines.md`
- `typos scripts/install-gitignore-in.sh scripts/test-install-gitignore-in.sh`
- `bash scripts/test-install-gitignore-in.sh`
- `bash scripts/test-update-version-usage.sh`
- `bash scripts/test-has-meaningful-gitignore-diff.sh`
- `bash scripts/test-run-with-timeout.sh`
- `bash scripts/test-run-with-timeout-signals.sh`
- `scripts/check-version-sha256-coherence.sh`
- `git diff --check`
- collateral check: clean
- implement-validator: `overall: pass`
