### PR TITLE
fix: emit diagnostic info when SHA-256 checksum entry is missing

### DIFF
--- a/scripts/install-gitignore-in.sh
+++ b/scripts/install-gitignore-in.sh
@@ -54,7 +54,14 @@ echo "Downloading ${url} (${RUNNER_OS}-${RUNNER_ARCH})" >&2
 wget --tries=3 --timeout=60 "${url}"
 
 if [ "${version}" = "${bundled_version}" ]; then
-	grep -F "  ${target}" "${repo_root}/bundled-binary.sha256" >"${target}.sha256"
+	if ! grep -F "  ${target}" "${repo_root}/bundled-binary.sha256" >"${target}.sha256"; then
+		echo "::error::No checksum entry found for '  ${target}' in bundled-binary.sha256" >&2
+		echo "  repo_root=${repo_root}" >&2
+		echo "  target=${target}" >&2
+		printf "  bundled-binary.sha256 contents:\n" >&2
+		cat "${repo_root}/bundled-binary.sha256" >&2
+		exit 1
+	fi
 	shasum -a 256 -c "${target}.sha256"
 else
 	echo "::warning::Custom gitignore-version '${version}' used; SHA-256 verification skipped because allow-unverified-gitignore-version=true. Only use for testing pre-release binaries." >&2


### PR DESCRIPTION
When the bundled binary version is used and the target platform's entry is absent from `bundled-binary.sha256`, `grep` exits non-zero but writes nothing to stderr. GitHub Actions surfaces only "Process completed with exit code 1." — leaving no indication of which file was searched, which pattern was expected, or what entries are actually present.

This change wraps the `grep` call in an explicit failure guard. On mismatch it now emits a GitHub Actions `::error::` annotation naming the missing entry, prints the resolved `GITHUB_ACTION_PATH` and `target` values, and dumps the full contents of `bundled-binary.sha256` to stderr — then exits with code 1. Successful runs are unaffected.

This makes failures after adding a new platform or bumping a version without regenerating the sha256 file immediately self-diagnosable from the CI log.
