### PR TITLE
Require version-coherence in branch ruleset

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,12 @@ jobs:
   required-status-checks:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Wait for the `test` aggregation gate: a `needs`-gated job does not register
-    # its status context until its dependencies finish, so this guard must run
-    # after it or it races and reports `test` as missing.
+    # Wait for required checks that can otherwise race this guard. The `test`
+    # aggregation gate does not register its status context until its
+    # dependencies finish, and `version-coherence` must be produced before the
+    # ruleset probe validates the configured required contexts.
     needs:
+      - version-coherence
       - test
     if: ${{ always() }}
     permissions:

--- a/scripts/configure-branch-ruleset.sh
+++ b/scripts/configure-branch-ruleset.sh
@@ -7,7 +7,7 @@
 # The ruleset is identified by name; the script fetches its ID automatically.
 #
 # Expected required checks (matching .github/workflows/*.yml job names):
-#   shell-format, check, shell-lint,
+#   shell-format, check, shell-lint, version-coherence,
 #   diff-detection (ubuntu-latest), diff-detection (macos-latest),
 #   test, test (boilerplates_ref passthrough), timeout helper
 
@@ -43,6 +43,7 @@ required_checks='[
   {"context":"shell-format"},
   {"context":"check"},
   {"context":"shell-lint"},
+  {"context":"version-coherence"},
   {"context":"diff-detection (ubuntu-latest)"},
   {"context":"diff-detection (macos-latest)"},
   {"context":"test"},

--- a/scripts/test-configure-branch-ruleset.sh
+++ b/scripts/test-configure-branch-ruleset.sh
@@ -45,8 +45,9 @@ esac
 SCRIPT
 chmod +x "${tmpdir}/gh"
 
-output=$(PATH="${tmpdir}:${PATH}" GH_MOCK_RULESETS=single scripts/configure-branch-ruleset.sh --dry-run)
+output=$(PATH="${tmpdir}:${PATH}" GH_MOCK_RULESETS=single scripts/configure-branch-ruleset.sh --dry-run 2>&1)
 printf '%s\n' "${output}" | grep 'Dry run: would update required_status_checks in ruleset 123'
+printf '%s\n' "${output}" | grep '"context":"version-coherence"'
 
 set +e
 output=$(PATH="${tmpdir}:${PATH}" GH_MOCK_RULESETS=none scripts/configure-branch-ruleset.sh --dry-run 2>&1)


### PR DESCRIPTION
## Summary

- Add `version-coherence` to the required status checks configured by `scripts/configure-branch-ruleset.sh`.
- Make the `required-status-checks` guard wait for `version-coherence` before it verifies the produced PR check contexts.
- Extend the ruleset dry-run test to assert that `version-coherence` is present in the desired required-check list.

## Notes

This PR is stacked on the branch that fixes the existing `version-coherence` extraction failure. That keeps this change focused on branch ruleset configuration without duplicating the coherence script fix.

## Verification

- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `shellcheck scripts/*.sh`
- `bash scripts/test-configure-branch-ruleset.sh`
- `scripts/check-version-sha256-coherence.sh`
- `typos .`
- `git diff --check`
- `bash scripts/test-has-meaningful-gitignore-diff.sh`
- `bash scripts/test-run-with-timeout.sh`
- `bash scripts/test-run-with-timeout-signals.sh`
- `bash scripts/test-update-version-usage.sh`
- collateral check: clean
- implement-validator: `overall: pass`
