### PR TITLE
Propagate ruleset API failures

### DIFF
--- a/scripts/configure-branch-ruleset.sh
+++ b/scripts/configure-branch-ruleset.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Apply required-status-checks to the default-branch-baseline ruleset.
 #
 # Usage: ./scripts/configure-branch-ruleset.sh [--dry-run]
@@ -11,7 +11,7 @@
 #   diff-detection (ubuntu-latest), diff-detection (macos-latest),
 #   test, test (boilerplates_ref passthrough), timeout helper
 
-set -eu
+set -euo pipefail
 
 REPO="gitignore-in/gh-action"
 RULESET_NAME="default-branch-baseline"

--- a/scripts/test-configure-branch-ruleset.sh
+++ b/scripts/test-configure-branch-ruleset.sh
@@ -30,6 +30,11 @@ case "${path}" in
 	duplicate)
 		printf '%s\n' '[{"name":"default-branch-baseline","id":123},{"name":"default-branch-baseline","id":456}]'
 		;;
+	list-fails)
+		echo "gh api ruleset list failed" >&2
+		printf '%s\n' '[]'
+		exit 1
+		;;
 	*)
 		echo "unexpected GH_MOCK_RULESETS=${GH_MOCK_RULESETS}" >&2
 		exit 2
@@ -37,6 +42,11 @@ case "${path}" in
 	esac
 	;;
 */rulesets/*)
+	if [ "${GH_MOCK_DETAIL:-ok}" = "fails" ]; then
+		echo "gh api ruleset detail failed" >&2
+		printf '%s\n' '{"rules":[]}'
+		exit 1
+	fi
 	# Ruleset detail: existing required_status_checks differs from desired,
 	# so the script reports that an update is needed.
 	printf '%s\n' '{"rules":[{"type":"required_status_checks","parameters":{"required_status_checks":[]}}]}'
@@ -64,3 +74,25 @@ set -e
 printf '%s\n' "${output}" | grep "Error: expected exactly one ruleset named 'default-branch-baseline', found 2"
 printf '%s\n' "${output}" | grep '123'
 printf '%s\n' "${output}" | grep '456'
+
+set +e
+output=$(PATH="${tmpdir}:${PATH}" GH_MOCK_RULESETS=list-fails scripts/configure-branch-ruleset.sh --dry-run 2>&1)
+status=$?
+set -e
+[ "${status}" -eq 1 ]
+printf '%s\n' "${output}" | grep 'gh api ruleset list failed'
+if printf '%s\n' "${output}" | grep -q "Error: ruleset 'default-branch-baseline' not found"; then
+	echo "ruleset list API failure was reported as a missing ruleset" >&2
+	exit 1
+fi
+
+set +e
+output=$(PATH="${tmpdir}:${PATH}" GH_MOCK_RULESETS=single GH_MOCK_DETAIL=fails scripts/configure-branch-ruleset.sh --dry-run 2>&1)
+status=$?
+set -e
+[ "${status}" -eq 1 ]
+printf '%s\n' "${output}" | grep 'gh api ruleset detail failed'
+if printf '%s\n' "${output}" | grep -q 'Dry run: would update required_status_checks'; then
+	echo "ruleset detail API failure was reported as an update diff" >&2
+	exit 1
+fi


### PR DESCRIPTION
## Summary

- Run `scripts/configure-branch-ruleset.sh` with Bash `pipefail` enabled.
- Add mock `gh api` failure cases for both ruleset-list and ruleset-detail reads.
- Keep upstream API failures from being reported as a missing ruleset or a required-check diff.

## Changed files

- `scripts/configure-branch-ruleset.sh`
- `scripts/test-configure-branch-ruleset.sh`

## Notes

This branch is stacked on #119 because that PR updates the same ruleset helper and carries the current `version-coherence` stack. The diff in this PR is limited to the API failure propagation behavior.

## Verification

- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `shellcheck scripts/*.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `bash scripts/test-configure-branch-ruleset.sh`
- repository shell helper tests
- version coherence check
- `typos .`
- `git diff --check`
- collateral check: clean
- implement-validator: `overall: pass`
