### PR TITLE
ci: add CI job to exercise custom gitignore-version code path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,6 +225,21 @@ jobs:
         with:
           boilerplates_ref: main
 
+  example-custom-gitignore-version:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: test (custom gitignore-version)
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: ./
+        with:
+          gitignore-version: v0.2.0
+      - name: verify binary is accessible after action
+        run: gitignore.in --version
+
   timeout-helper:
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## Summary

The `gitignore-version` input (added in PR #103) lets callers specify a
custom version instead of the bundled default. The download-and-install
code in `action.yml` has an `if/else` branch:

- `if` — version matches bundled (`v0.2.1`): SHA-256 verified from
  `bundled-binary.sha256`
- `else` — custom version: download from GitHub Releases, SHA-256 skipped

Both existing CI jobs (`example` and `example-pinned-boilerplates`) omit
the `gitignore-version` input, so the `else` branch has never been exercised
by CI. Regressions in the download, extract, or install steps would not be
caught.

## Change

Adds a new CI job `example-custom-gitignore-version` that invokes the
action with `gitignore-version: v0.2.0` (a prior stable release). This
exercises the custom-version download path end-to-end on every CI run.

## Verification

- Job structure and permissions match the existing `example` job
- `v0.2.0` release exists in `gitignore-in/gitignore-in`
- Smoke test: `gitignore.in --version` runs after install