### PR TITLE
docs: describe the maintainer docs directory

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# Maintainer documentation
+
+This directory holds maintainer-facing documentation for the action's
+operational and release workflows. It is separate from the root README so the
+root can stay focused on consumer setup and action inputs.
+
+## Documents
+
+- [Release governance](RELEASE.md): release cadence, bundled binary update
+  responsibilities, and reference policy.
+- [Operational state machines](state-machines.md): state boundaries for
+  consumer pull requests, draft releases, bundled binary updates, and workflow
+  concurrency.
+
+## Placement
+
+Add documents here when they describe how this repository is maintained or how
+its automation behaves over time. Keep consumer-facing usage instructions in
+the root [README](../README.md), and link to deeper maintainer documents from
+there when users need the operational context.


### PR DESCRIPTION
## Summary

- Add a `docs/README.md` index for maintainer-facing documentation.
- Document why operational and release workflow notes live under `docs/`.
- Point readers to the release governance and operational state machine documents.

## Notes

This branch is based on #114 because `main` currently has an unrelated
version-coherence failure that #114 fixes. The documentation change itself is
limited to `docs/README.md`.

## Verification

- `typos docs/README.md`
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `shellcheck scripts/*.sh`
- `scripts/check-version-sha256-coherence.sh`
- `bash scripts/test-has-meaningful-gitignore-diff.sh`
- `bash scripts/test-run-with-timeout.sh`
- collateral check: clean
- `git diff --check`
