### PR TITLE
Allow branch ruleset script to target another repository

### DIFF
--- a/scripts/configure-branch-ruleset.sh
+++ b/scripts/configure-branch-ruleset.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Apply required-status-checks to the default-branch-baseline ruleset.
 #
-# Usage: ./scripts/configure-branch-ruleset.sh [--dry-run]
+# Usage: ./scripts/configure-branch-ruleset.sh [--dry-run] [--repo owner/repo]
 #
 # Requires: gh CLI with admin token (repo scope).
 # The ruleset is identified by name; the script fetches its ID automatically.
@@ -14,13 +14,39 @@
 
 set -euo pipefail
 
-REPO="gitignore-in/gh-action"
+REPO="${GITHUB_REPOSITORY:-gitignore-in/gh-action}"
 RULESET_NAME="default-branch-baseline"
 DRY_RUN=false
 
-if [ "${1:-}" = "--dry-run" ]; then
-	DRY_RUN=true
-fi
+usage() {
+	echo "Usage: $0 [--dry-run] [--repo owner/repo]"
+}
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+	--dry-run)
+		DRY_RUN=true
+		shift
+		;;
+	--repo)
+		if [ "$#" -lt 2 ]; then
+			usage >&2
+			exit 2
+		fi
+		REPO="$2"
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "Error: unknown argument: $1" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
+done
 
 ruleset_ids=$(gh api "repos/${REPO}/rulesets" |
 	jq -r --arg name "${RULESET_NAME}" '.[] | select(.name == $name) | .id')

--- a/scripts/test-configure-branch-ruleset.sh
+++ b/scripts/test-configure-branch-ruleset.sh
@@ -17,8 +17,9 @@ for arg in "$@"; do
 		;;
 	esac
 done
+expected_rulesets_path="repos/${GH_EXPECT_REPO:-gitignore-in/gh-action}/rulesets"
 case "${path}" in
-*/rulesets)
+"${expected_rulesets_path}")
 	# Ruleset list: returned as a JSON array, matching the GitHub API shape.
 	case "${GH_MOCK_RULESETS:-single}" in
 	single)
@@ -51,6 +52,10 @@ case "${path}" in
 	# so the script reports that an update is needed.
 	printf '%s\n' '{"rules":[{"type":"required_status_checks","parameters":{"required_status_checks":[]}}]}'
 	;;
+*)
+	echo "unexpected gh api path: ${path}; expected ${expected_rulesets_path}" >&2
+	exit 2
+	;;
 esac
 SCRIPT
 chmod +x "${tmpdir}/gh"
@@ -58,6 +63,19 @@ chmod +x "${tmpdir}/gh"
 output=$(PATH="${tmpdir}:${PATH}" GH_MOCK_RULESETS=single scripts/configure-branch-ruleset.sh --dry-run 2>&1)
 printf '%s\n' "${output}" | grep 'Dry run: would update required_status_checks in ruleset 123'
 printf '%s\n' "${output}" | grep '"context":"version-coherence"'
+
+output=$(PATH="${tmpdir}:${PATH}" GITHUB_REPOSITORY=example/fork GH_EXPECT_REPO=example/fork GH_MOCK_RULESETS=single scripts/configure-branch-ruleset.sh --dry-run 2>&1)
+printf '%s\n' "${output}" | grep 'Dry run: would update required_status_checks in ruleset 123'
+
+output=$(PATH="${tmpdir}:${PATH}" GH_EXPECT_REPO=example/fork GH_MOCK_RULESETS=single scripts/configure-branch-ruleset.sh --repo example/fork --dry-run 2>&1)
+printf '%s\n' "${output}" | grep 'Dry run: would update required_status_checks in ruleset 123'
+
+set +e
+output=$(PATH="${tmpdir}:${PATH}" GH_MOCK_RULESETS=single scripts/configure-branch-ruleset.sh --repo 2>&1)
+status=$?
+set -e
+[ "${status}" -eq 2 ]
+printf '%s\n' "${output}" | grep 'Usage:'
 
 set +e
 output=$(PATH="${tmpdir}:${PATH}" GH_MOCK_RULESETS=none scripts/configure-branch-ruleset.sh --dry-run 2>&1)


### PR DESCRIPTION
Summary:
- Let the branch-ruleset maintenance script read the target repository from `GITHUB_REPOSITORY` or `--repo owner/name`, while keeping the current repository as the default.
- Add focused regression coverage for default, environment, and CLI repository selection paths.

Verification:
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `shellcheck scripts/*.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `bash scripts/test-configure-branch-ruleset.sh`
- `bash -n scripts/configure-branch-ruleset.sh scripts/test-configure-branch-ruleset.sh`

Dependency: This PR is temporarily based on #114 because that PR restores the version-coherence CI check on the current base branch. No code from that fix is included here.
