### PR TITLE
Run branch ruleset script tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -240,5 +240,8 @@ jobs:
       - name: stops command group when wrapper receives SIGTERM
         run: bash scripts/test-run-with-timeout-signals.sh
 
+      - name: exercises branch ruleset configuration lookup
+        run: bash scripts/test-configure-branch-ruleset.sh
+
       - name: uses exit 2 for update-version usage errors
         run: bash scripts/test-update-version-usage.sh

--- a/scripts/test-configure-branch-ruleset.sh
+++ b/scripts/test-configure-branch-ruleset.sh
@@ -45,7 +45,7 @@ esac
 SCRIPT
 chmod +x "${tmpdir}/gh"
 
-output=$(PATH="${tmpdir}:${PATH}" GH_MOCK_RULESETS=single scripts/configure-branch-ruleset.sh --dry-run)
+output=$(PATH="${tmpdir}:${PATH}" GH_MOCK_RULESETS=single scripts/configure-branch-ruleset.sh --dry-run 2>&1)
 printf '%s\n' "${output}" | grep 'Dry run: would update required_status_checks in ruleset 123'
 
 set +e


### PR DESCRIPTION
## Summary
- Adds the branch-ruleset configuration test to CI so the existing script test runs on every pull request.
- Tightens the test helper to capture the script's dry-run output reliably.

## Verification
- `bash scripts/test-configure-branch-ruleset.sh`
- `bash scripts/test-run-with-timeout.sh && bash scripts/test-run-with-timeout-signals.sh && bash scripts/test-update-version-usage.sh && bash scripts/test-configure-branch-ruleset.sh`
- `shfmt -d scripts/*.sh`
- `shellcheck scripts/*.sh`
- `actionlint -color`
- `git diff --check`
- collateral check clean
- implement-validator overall: pass
