### PR TITLE
ci: add version-coherence to required status checks

### DIFF
--- a/scripts/configure-branch-ruleset.sh
+++ b/scripts/configure-branch-ruleset.sh
@@ -9,7 +9,8 @@
 # Expected required checks (matching .github/workflows/*.yml job names):
 #   shell-format, check, shell-lint,
 #   diff-detection (ubuntu-latest), diff-detection (macos-latest),
-#   test, test (boilerplates_ref passthrough), timeout helper
+#   test, test (boilerplates_ref passthrough), timeout helper,
+#   version-coherence
 
 set -eu
 
@@ -47,7 +48,8 @@ required_checks='[
   {"context":"diff-detection (macos-latest)"},
   {"context":"test"},
   {"context":"test (boilerplates_ref passthrough)"},
-  {"context":"timeout helper"}
+  {"context":"timeout helper"},
+  {"context":"version-coherence"}
 ]'
 
 current_sorted=$(gh api "repos/${REPO}/rulesets/${ruleset_id}" |


### PR DESCRIPTION
## Summary

The `version-coherence` job was added to `.github/workflows/main.yml` to
verify that the bundle version in `action.yml` matches `bundled-binary.sha256`.
However, the job was not registered in `scripts/configure-branch-ruleset.sh`
as a required status check, so a failure would not block PR merges.

## Changes

- Added `{"context":"version-coherence"}` to the `required_checks` list in
  `scripts/configure-branch-ruleset.sh`
- Updated the comment at the top of the script to list `version-coherence`

## Effect

After running `./scripts/configure-branch-ruleset.sh`, the `version-coherence`
check will be enforced on the default branch. PRs where `action.yml` and
`bundled-binary.sha256` are inconsistent will be blocked from merging.

## Verification

- `shfmt` formatting: no changes
- `shellcheck`: no issues
- `actionlint`: no issues