### PR TITLE
Cache gitignore.in release archives

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -96,6 +96,12 @@ runs:
     - uses: gitignore-in/install-gibo@190df5cc5be7f64b8364a04f9c84e2cfa7b1cd32
       with:
         boilerplates-ref: ${{ inputs.boilerplates_ref }}
+    - name: cache gitignore.in binary
+      id: gitignore-in-cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/gitignore-in
+        key: gitignore-in-${{ runner.os }}-${{ runner.arch }}-${{ inputs.gitignore-version }}-v1
     - run: |
         set -euo pipefail
         tmpdir=$(mktemp -d)
@@ -121,19 +127,51 @@ runs:
             exit 1
             ;;
         esac
-        url="https://github.com/gitignore-in/gitignore-in/releases/download/${version}/${target}"
-        echo "Downloading ${url} (${RUNNER_OS}-${RUNNER_ARCH})" >&2
-        wget --tries=3 --timeout=60 "${url}"
-        if [ "${version}" = "${bundled_version}" ]; then
-          grep -F "  ${target}" "${GITHUB_ACTION_PATH}/bundled-binary.sha256" > "${target}.sha256"
-          shasum -a 256 -c "${target}.sha256"
-        else
-          echo "::warning::Custom gitignore-version '${version}' used; SHA-256 verification skipped. Only use for testing pre-release binaries." >&2
-        fi
-        tar -xzf "${target}"
+        cache_dir="${RUNNER_TEMP}/gitignore-in/${RUNNER_OS}-${RUNNER_ARCH}/${version}"
+        archive="${cache_dir}/${target}"
+        mkdir -p "${cache_dir}"
         mkdir -p "${RUNNER_TEMP}/gitignore-in/bin"
-        install -m 0755 gitignore.in "${tmpdir}/gitignore.in.installed"
-        mv "${tmpdir}/gitignore.in.installed" "${RUNNER_TEMP}/gitignore-in/bin/gitignore.in"
+        url="https://github.com/gitignore-in/gitignore-in/releases/download/${version}/${target}"
+        use_cached="false"
+        if [ -f "${archive}" ]; then
+          use_cached="true"
+          if [ "${version}" = "${bundled_version}" ]; then
+            expected=$(awk -v t="${target}" '$2 == t { print $1 }' "${GITHUB_ACTION_PATH}/bundled-binary.sha256")
+            if [ -z "${expected}" ]; then
+              echo "checksum for ${target} is not found in bundled-binary.sha256" >&2
+              exit 1
+            fi
+            actual=$(shasum -a 256 "${archive}" | awk "{print \$1}")
+            if [ "${expected}" != "${actual}" ]; then
+              echo "Cached archive checksum mismatch. Re-downloading." >&2
+              use_cached="false"
+              rm -f "${archive}"
+            fi
+          fi
+        fi
+        if [ "${use_cached}" != "true" ]; then
+          echo "Downloading ${url} (${RUNNER_OS}-${RUNNER_ARCH})" >&2
+          wget --tries=3 --timeout=60 "${url}"
+          if [ "${version}" = "${bundled_version}" ]; then
+            expected=$(awk -v t="${target}" '$2 == t { print $1 }' "${GITHUB_ACTION_PATH}/bundled-binary.sha256")
+            if [ -z "${expected}" ]; then
+              echo "checksum for ${target} is not found in bundled-binary.sha256" >&2
+              exit 1
+            fi
+            downloaded=$(shasum -a 256 "${target}" | awk "{print \$1}")
+            if [ "${expected}" != "${downloaded}" ]; then
+              echo "downloaded binary checksum mismatch" >&2
+              exit 1
+            fi
+          else
+            echo "::warning::Custom gitignore-version '${version}' used; SHA-256 verification skipped. Only use for testing pre-release binaries." >&2
+          fi
+          mv "${target}" "${archive}"
+        else
+          echo "Using cached gitignore.in archive for ${version}." >&2
+        fi
+        tar -xzf "${archive}"
+        install -m 0755 gitignore.in "${RUNNER_TEMP}/gitignore-in/bin/gitignore.in"
         echo "${RUNNER_TEMP}/gitignore-in/bin" >> "${GITHUB_PATH}"
       env:
         GITIGNORE_IN_VERSION: ${{ inputs.gitignore-version }}


### PR DESCRIPTION
Adds an actions/cache layer for downloaded gitignore.in release archives.

The bundled release archive is still verified with the existing SHA-256 list before it is stored or reused.