### PR TITLE
Updated the action metadata and public documentation so `gitignore-vers…

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Windows and other platforms are not supported. The action exits with an error if
 | `pr_body` | Pull request body | `Update .gitignore by gitignore.in` |
 | `delete_branch` | Delete the branch after merge | `true` |
 | `boilerplates_ref` | Git ref (branch, tag, or SHA) of the [toptal/gitignore](https://github.com/toptal/gitignore) boilerplates database to pin. When set, every run produces identical `.gitignore` output for the same `.gitignore.in` template. Leave empty to always use the latest boilerplates (default, non-deterministic). | `""` |
-| `gitignore-version` | Version of the `gitignore-in` binary to download (e.g. `v0.2.1`). When set to the bundled default, the binary is verified against `bundled-binary.sha256`. Custom versions require explicit opt-in. | `v0.2.1` |
-| `allow-unverified-gitignore-version` | Allow a custom `gitignore-version` without SHA-256 verification. Leave this disabled unless you are intentionally testing a pre-release binary. | `false` |
+| `gitignore-version` | Version of the `gitignore-in` binary to download (e.g. `v0.2.1`). This input selects the release artifact only. | `v0.2.1` |
+| `allow-unverified-gitignore-version` | Checksum policy for non-bundled `gitignore-version` values. Leave this disabled unless you are intentionally testing a pre-release binary. | `false` |
 | `timeout_seconds` | Positive timeout in seconds for the `gitignore.in` generation step. Lower this value for fail-fast workflows or raise it for slow runners. | `300` |
 
 > **Note on input naming:** The existing inputs above (`branch_name`, `base_branch`, etc.) use
@@ -81,7 +81,7 @@ Windows and other platforms are not supported. The action exits with an error if
 > `kebab-case`; until then, the table above shows the exact key names to use in `with:`.
 >
 > If you override `gitignore-version`, set `allow-unverified-gitignore-version: "true"` to opt in
-> to the unverified download path.
+> to the unverified download path. The version selector and checksum policy are separate inputs.
 
 ### Pinning the boilerplates database
 

--- a/action.yml
+++ b/action.yml
@@ -56,16 +56,15 @@ inputs:
     description: |
       Version of the gitignore-in binary to download (e.g. v0.2.1).
       Defaults to the version bundled with this action release.
-      When set to the bundled version, the download is verified against
-      bundled-binary.sha256. Custom versions require explicit opt-in via
-      allow-unverified-gitignore-version because SHA-256 verification is
-      otherwise enforced.
-    required: false
-    default: "v0.2.1"
+      This input selects the release artifact only; checksum policy is
+      controlled separately by allow-unverified-gitignore-version.
+  required: false
+  default: "v0.2.1"
   allow-unverified-gitignore-version:
     description: |
       Allow a custom gitignore-version without SHA-256 verification.
-      Leave false to reject unverified custom versions.
+      Leave false to reject unverified custom versions and keep the bundled
+      release checksum-verified.
     required: false
     default: "false"
   timeout_seconds:

--- a/action.yml
+++ b/action.yml
@@ -58,15 +58,15 @@ inputs:
       Defaults to the version bundled with this action release.
       This input selects the release artifact only; checksum policy is
       controlled separately by allow-unverified-gitignore-version.
-  required: false
-  default: "v0.2.1"
+    required: false
+    default: !!str v0.2.1
   allow-unverified-gitignore-version:
     description: |
       Allow a custom gitignore-version without SHA-256 verification.
       Leave false to reject unverified custom versions and keep the bundled
       release checksum-verified.
     required: false
-    default: "false"
+    default: !!str false
   timeout_seconds:
     description: |
       Positive timeout in seconds for the gitignore.in generation step.

--- a/action.yml
+++ b/action.yml
@@ -59,14 +59,14 @@ inputs:
       This input selects the release artifact only; checksum policy is
       controlled separately by allow-unverified-gitignore-version.
     required: false
-    default: !!str v0.2.1
+    default: "v0.2.1"
   allow-unverified-gitignore-version:
     description: |
       Allow a custom gitignore-version without SHA-256 verification.
       Leave false to reject unverified custom versions and keep the bundled
       release checksum-verified.
     required: false
-    default: !!str false
+    default: "false"
   timeout_seconds:
     description: |
       Positive timeout in seconds for the gitignore.in generation step.

--- a/docs/state-machines.md
+++ b/docs/state-machines.md
@@ -8,9 +8,9 @@ implicit behavior from third-party actions.
 ## Download verification
 
 The composite action downloads the `gitignore.in` binary before generating a
-consumer `.gitignore`. The download path is controlled by the requested
-`gitignore-version` and by whether that version matches the action metadata
-default.
+consumer `.gitignore`. The requested `gitignore-version` selects the release
+artifact, and `allow-unverified-gitignore-version` separately decides whether a
+non-bundled version may skip repository-owned checksum verification.
 
 States:
 


### PR DESCRIPTION
## Summary

Updated the action metadata and public documentation so `gitignore-version` is presented as a pure release selector while `allow-unverified-gitignore-version` carries the checksum-policy decision separately.

## Chosen fix

- approach: surface

---
Automated implementation for kimono-tasks finding `findings/gitignore-in/gh-action/audit-api-surface-quality-audit-001.yaml`.