### PR TITLE
Make `has-meaningful-gitignore-diff.sh` detection conservative

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,7 +9,7 @@ as part of the action. Renaming or moving them is a breaking change.
 
 | Script | Purpose |
 | --- | --- |
-| `has-meaningful-gitignore-diff.sh` | Determines whether a `.gitignore` diff contains meaningful changes (ignoring comment-only lines) |
+| `has-meaningful-gitignore-diff.sh` | Determines whether a `.gitignore` diff contains meaningful changes while ignoring only end-of-line whitespace |
 | `run-with-timeout.sh` | Runs a command with a timeout, forwarding signals for clean shutdown |
 
 ## Development tooling

--- a/scripts/has-meaningful-gitignore-diff.sh
+++ b/scripts/has-meaningful-gitignore-diff.sh
@@ -14,8 +14,33 @@ if ! git diff --name-only -- "${target}" | grep -q .; then
 	exit 0
 fi
 
-if git diff --ignore-space-at-eol --quiet -- "${target}"; then
-	echo "changed=false" >>"${GITHUB_OUTPUT:-/dev/stdout}"
-else
+if git diff --ignore-space-at-eol -- "${target}" |
+	awk '
+		/^diff --git / { in_hunk = 0; next }
+		/^@@ / { in_hunk = 1; next }
+		in_hunk && /^[+-]/ {
+			sign = substr($0, 1, 1)
+			content = substr($0, 2)
+			if (content ~ /^[[:space:]]*($|#)/) {
+				next
+			}
+			keys[content] = 1
+			if (sign == "-") {
+				removed[content]++
+			} else {
+				added[content]++
+			}
+		}
+		END {
+			for (content in keys) {
+				if (removed[content] != added[content]) {
+					found = 1
+				}
+			}
+			exit found ? 0 : 1
+		}
+	'; then
 	echo "changed=true" >>"${GITHUB_OUTPUT:-/dev/stdout}"
+else
+	echo "changed=false" >>"${GITHUB_OUTPUT:-/dev/stdout}"
 fi

--- a/scripts/has-meaningful-gitignore-diff.sh
+++ b/scripts/has-meaningful-gitignore-diff.sh
@@ -14,33 +14,8 @@ if ! git diff --name-only -- "${target}" | grep -q .; then
 	exit 0
 fi
 
-if git diff --ignore-space-at-eol -- "${target}" |
-	awk '
-		/^diff --git / { in_hunk = 0; next }
-		/^@@ / { in_hunk = 1; next }
-		in_hunk && /^[+-]/ {
-			sign = substr($0, 1, 1)
-			content = substr($0, 2)
-			sub(/^[[:space:]]+/, "", content)
-			if (content !~ /^(#|$)/) {
-				keys[content] = 1
-				if (sign == "-") {
-					removed[content]++
-				} else {
-					added[content]++
-				}
-			}
-		}
-		END {
-			for (content in keys) {
-				if (removed[content] != added[content]) {
-					found = 1
-				}
-			}
-			exit found ? 0 : 1
-		}
-	'; then
-	echo "changed=true" >>"${GITHUB_OUTPUT:-/dev/stdout}"
-else
+if git diff --ignore-space-at-eol --quiet -- "${target}"; then
 	echo "changed=false" >>"${GITHUB_OUTPUT:-/dev/stdout}"
+else
+	echo "changed=true" >>"${GITHUB_OUTPUT:-/dev/stdout}"
 fi

--- a/scripts/test-has-meaningful-gitignore-diff.sh
+++ b/scripts/test-has-meaningful-gitignore-diff.sh
@@ -35,10 +35,16 @@ run_tracked_case() {
 }
 
 run_tracked_case \
-	"leading whitespace-only pattern diff is ignored" \
-	false \
+	"leading whitespace change is meaningful" \
+	true \
 	$'node_modules/\n.env\n' \
 	$'node_modules/\n  .env\n'
+
+run_tracked_case \
+	"literal hash pattern change is meaningful" \
+	true \
+	$'node_modules/\n.env\n' \
+	$'node_modules/\n\\#build\n'
 
 run_tracked_case \
 	"changed pattern is meaningful" \


### PR DESCRIPTION
## Summary

Replaced `scripts/has-meaningful-gitignore-diff.sh` with a conservative check based on `git diff --ignore-space-at-eol --quiet` so content differences in `.gitignore` are no longer missed. Added regression tests for leading spaces and literal `#`, and updated the description.
