### PR TITLE
fix: PR creation fails silently when the token lacks write permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -254,3 +254,6 @@ jobs:
 
       - name: install helper handles bundled and unverified versions
         run: bash scripts/test-install-gitignore-in.sh
+
+      - name: pull request permissions helper fails fast when token cannot write
+        run: bash scripts/test-check-create-pull-request-permissions.sh

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ steps:
 ```
 
 > **Note:** Repositories whose default token permissions are set to read-only (common in organizations) must declare `contents: write` and `pull-requests: write` explicitly. The action uses `github.token` to create the pull request via `peter-evans/create-pull-request`, so without these permissions the PR step will fail silently.
+> The action now checks those permissions before creating the PR and stops with a clear error if they are missing.
 
 For production use, pin to a specific tag or SHA to avoid unexpected changes:
 

--- a/action.yml
+++ b/action.yml
@@ -136,6 +136,14 @@ runs:
       shell: bash
       working-directory: repository
 
+    - name: preflight pull request permissions
+      if: steps.check.outputs.changed == 'true'
+      run: |
+        "${GITHUB_ACTION_PATH}/scripts/check-create-pull-request-permissions.sh"
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+
     - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
       if: steps.check.outputs.changed == 'true'
       id: create_pull_request

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,7 +9,8 @@ as part of the action. Renaming or moving them is a breaking change.
 
 | Script | Purpose |
 | --- | --- |
-| `has-meaningful-gitignore-diff.sh` | Determines whether a `.gitignore` diff contains meaningful changes while ignoring only end-of-line whitespace |
+| `check-create-pull-request-permissions.sh` | Fails fast when the Actions token cannot write repository contents and pull requests |
+| `has-meaningful-gitignore-diff.sh` | Determines whether a `.gitignore` diff contains meaningful changes (ignoring comment-only lines) |
 | `run-with-timeout.sh` | Runs a command with a timeout, forwarding signals for clean shutdown |
 
 ## Development tooling

--- a/scripts/check-create-pull-request-permissions.sh
+++ b/scripts/check-create-pull-request-permissions.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GITHUB_REPOSITORY:-}"
+api_url="${GITHUB_API_URL:-https://api.github.com}"
+token="${GITHUB_TOKEN:-}"
+
+if [ -z "${repo}" ]; then
+	echo "usage: GITHUB_REPOSITORY=<owner>/<repo> GITHUB_TOKEN=<token> $0" >&2
+	exit 2
+fi
+
+if [ -z "${token}" ]; then
+	echo "::error::GITHUB_TOKEN is required to preflight repository write permissions before creating a pull request." >&2
+	exit 1
+fi
+
+repo_json="$(
+	curl -fsSL \
+		-H "Authorization: Bearer ${token}" \
+		-H "Accept: application/vnd.github+json" \
+		-H "X-GitHub-Api-Version: 2022-11-28" \
+		"${api_url}/repos/${repo}"
+)"
+
+permissions="$(
+	printf '%s' "${repo_json}" | ruby -e '
+		require "json"
+		data = JSON.parse(STDIN.read)
+		perms = data.fetch("permissions", {})
+		puts [perms["push"], perms["pull"]].map { |value| value ? "true" : "false" }.join(" ")
+	'
+)"
+
+read -r push_permission pull_permission <<<"${permissions}"
+push_permission="${push_permission:-false}"
+pull_permission="${pull_permission:-false}"
+
+if [ "${push_permission}" != "true" ] || [ "${pull_permission}" != "true" ]; then
+	echo "::error::This action needs repository write access for both contents and pull requests. GitHub reported permissions.push=${push_permission} permissions.pull=${pull_permission}; add permissions: contents: write and pull-requests: write to the consumer workflow." >&2
+	exit 1
+fi

--- a/scripts/test-check-create-pull-request-permissions.sh
+++ b/scripts/test-check-create-pull-request-permissions.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+helper="${script_dir}/check-create-pull-request-permissions.sh"
+
+make_fixture() {
+	local fixture_dir
+	fixture_dir="$(mktemp -d)"
+	mkdir -p "${fixture_dir}/bin"
+
+	cat >"${fixture_dir}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "${STUB_PERMISSION_JSON:-}"
+EOF
+
+	chmod +x "${fixture_dir}/bin/curl"
+	printf '%s\n' "${fixture_dir}"
+}
+
+run_helper() {
+	local fixture_dir="$1"
+	local permission_json="$2"
+	env \
+		PATH="${fixture_dir}/bin:${PATH}" \
+		GITHUB_REPOSITORY="gitignore-in/gh-action" \
+		GITHUB_TOKEN="test-token" \
+		GITHUB_API_URL="https://api.github.com" \
+		STUB_PERMISSION_JSON="${permission_json}" \
+		"${helper}"
+}
+
+assert_failure_contains() {
+	local expected="$1"
+	local output="$2"
+	if ! grep -F -- "${expected}" <<<"${output}" >/dev/null; then
+		echo "expected output to contain: ${expected}" >&2
+		echo "${output}" >&2
+		exit 1
+	fi
+}
+
+test_allows_write_permissions() {
+	local fixture_dir output status
+	fixture_dir="$(make_fixture)"
+
+	set +e
+	output="$(
+		run_helper "${fixture_dir}" '{"permissions":{"push":true,"pull":true}}' 2>&1
+	)"
+	status=$?
+	set -e
+
+	if [ "${status}" -ne 0 ]; then
+		echo "${output}" >&2
+		exit 1
+	fi
+}
+
+test_rejects_missing_write_permissions() {
+	local fixture_dir output status
+	fixture_dir="$(make_fixture)"
+
+	set +e
+	output="$(
+		run_helper "${fixture_dir}" '{"permissions":{"push":true,"pull":false}}' 2>&1
+	)"
+	status=$?
+	set -e
+
+	if [ "${status}" -eq 0 ]; then
+		echo "expected missing permissions to fail" >&2
+		exit 1
+	fi
+	assert_failure_contains "permissions.push=true permissions.pull=false" "${output}"
+	assert_failure_contains "contents: write" "${output}"
+	assert_failure_contains "pull-requests: write" "${output}"
+}
+
+test_requires_token() {
+	local fixture_dir output status
+	fixture_dir="$(make_fixture)"
+
+	set +e
+	output="$(
+		env \
+			PATH="${fixture_dir}/bin:${PATH}" \
+			GITHUB_REPOSITORY="gitignore-in/gh-action" \
+			GITHUB_API_URL="https://api.github.com" \
+			"${helper}" 2>&1
+	)"
+	status=$?
+	set -e
+
+	if [ "${status}" -eq 0 ]; then
+		echo "expected missing token to fail" >&2
+		exit 1
+	fi
+	assert_failure_contains "GITHUB_TOKEN is required" "${output}"
+}
+
+test_allows_write_permissions
+test_rejects_missing_write_permissions
+test_requires_token


### PR DESCRIPTION
## Finding

The README requires explicit `contents: write` and `pull-requests: write`, but the action itself neither validates nor enforces permissions; when PR creation with `github.token` fails, PR generation stops silently.

## Why

Automatically creating pull requests is this action's main function, yet it has no built-in permission check. With the organization-common read-only default token it appears to succeed while no PR is created. Users who miss the README note cannot notice that their CI automation has been disabled.

## Impact

When adopted with insufficient permissions, `.gitignore` updates are never turned into PRs and the CI automation does not function. Updates get dropped and CI-dependent operations become unstable — especially hard to notice in organizations whose default token is read-only.
