### PR TITLE
ci-operations: track version-coherence gap via the existing finding

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,10 +184,13 @@ jobs:
 
   # Aggregation gate that produces the bare `test` status context required by
   # the `default-branch-baseline` ruleset. The platform matrix above reports as
-  # `test (ubuntu-latest)` / `test (macos-latest)`, so this job re-exposes a
-  # single `test` context that is green only when every matrix leg succeeds.
+  # `test (ubuntu-latest)` / `test (macos-latest)`, and `version-coherence`
+  # is a separate required signal, so this job re-exposes a single `test`
+  # context that is green only when every matrix leg and the coherence check
+  # succeed.
   test:
     needs:
+      - version-coherence
       - example
     if: ${{ always() }}
     runs-on: ubuntu-latest
@@ -197,7 +200,9 @@ jobs:
     steps:
       - name: example matrix succeeded on all platforms
         run: |
+          coherence_result='${{ needs.version-coherence.result }}'
           result='${{ needs.example.result }}'
+          test "${coherence_result}" = success
           test "${result}" = success
 
   example-pinned-boilerplates:


### PR DESCRIPTION
## Finding

No new ci-operations finding is filed: the same issue is already tracked by an unresolved finding in this category, and filing a duplicate would be operational noise.

## Why

The audited change concerns the known CI-consistency gap — the `version-coherence` job not being registered as a required check — which is already tracked by an open `ci-operations` finding, so consolidating into the existing issue is appropriate rather than filing a new one.

## Impact

Registering the same problem across multiple findings would scatter priorities and completion criteria, raising the risk of duplicate fix proposals.
