### PR TITLE
fix: cover gitignore-diff suppression cases in portable tests

### DIFF
--- a/scripts/test-has-meaningful-gitignore-diff.sh
+++ b/scripts/test-has-meaningful-gitignore-diff.sh
@@ -51,3 +51,21 @@ run_tracked_case \
 	true \
 	$'node_modules/\n.env\n' \
 	$'node_modules/\nbuild/\n'
+
+run_tracked_case \
+	"comment-only diff is ignored" \
+	false \
+	$'node_modules/\n.env\n' \
+	$'node_modules/\n.env\n\n # comment-only change\n\t# tab-indented comment-only change\n'
+
+run_tracked_case \
+	"whitespace-only diff is ignored" \
+	false \
+	$'node_modules/\n.env\n' \
+	$'node_modules/\n.env\n\n   \n\t\n'
+
+run_tracked_case \
+	"missing final newline diff is ignored" \
+	false \
+	'node_modules/' \
+	$'node_modules/\n'


### PR DESCRIPTION
## Why

`has-meaningful-gitignore-diff.sh` has three suppression paths in its awk
filter (comment-only diff, whitespace-only diff, missing final newline) that
prevent a spurious PR when a `.gitignore` diff has no meaningful content.
`scripts/test-has-meaningful-gitignore-diff.sh` only asserted the `changed=true`
paths; the `changed=false` (suppression) paths were only covered by inline
steps in `.github/workflows/main.yml`'s `diff-detection` job, which cannot be
run outside CI. A developer editing the awk filter and running the portable
test script locally would see all assertions pass with zero signal that the
suppression logic -- the property that guards against spurious PRs -- had
regressed.

## What changed

Added three `changed=false` cases to `scripts/test-has-meaningful-gitignore-diff.sh`,
mirroring the existing inline CI assertions:

- comment-only diff is ignored
- whitespace-only diff is ignored
- missing final newline diff is ignored

No other files change; the existing inline CI steps in `main.yml` are left as is.

## Verification

- Ran the updated `scripts/test-has-meaningful-gitignore-diff.sh` locally: all
  seven cases (four pre-existing `changed=true`, three new `changed=false`)
  pass.
- Ran `shfmt -d` and `shellcheck` on the changed file: both clean.
- Confirmed the new cases are not vacuous: temporarily forced the awk filter
  in `has-meaningful-gitignore-diff.sh` to always report a change, reran the
  test script, and observed the new `changed=false` assertions fail as
  expected (e.g. "comment-only diff is ignored: expected changed=false").
